### PR TITLE
fix(helm): use sslmode=require for psycopg3 migration compatibility

### DIFF
--- a/infra/helm/core-api/templates/external-secret.yaml
+++ b/infra/helm/core-api/templates/external-secret.yaml
@@ -26,9 +26,9 @@ spec:
         # Construct DB_URL from fetched credentials and endpoint.
         # Prefer explicit chart endpoint; if blank, use host in secret.
         # Secret JSON created by RDS typically contains: username, password, host (or endpoint), port
-        # Note: Using ssl=require for asyncpg compatibility (app converts psycopg -> asyncpg)
+        # Note: Using sslmode=require for psycopg3 compatibility (app converts psycopg -> asyncpg)
         {{- /* We cannot do ternary inside the external-secrets template interpolation, so we expose both and rely on chart value when set */}}
-        DB_URL: "postgresql+psycopg://{{`{{ .username }}`}}:{{`{{ .password }}`}}@{{- if .Values.externalSecrets.dbEndpoint | and (ne .Values.externalSecrets.dbEndpoint "") -}}{{ .Values.externalSecrets.dbEndpoint }}{{- else -}}{{`{{ .host }}`}}{{- end }}:{{ .Values.externalSecrets.dbPort }}/{{ .Values.externalSecrets.dbName }}?ssl=require"
+        DB_URL: "postgresql+psycopg://{{`{{ .username }}`}}:{{`{{ .password }}`}}@{{- if .Values.externalSecrets.dbEndpoint | and (ne .Values.externalSecrets.dbEndpoint "") -}}{{ .Values.externalSecrets.dbEndpoint }}{{- else -}}{{`{{ .host }}`}}{{- end }}:{{ .Values.externalSecrets.dbPort }}/{{ .Values.externalSecrets.dbName }}?sslmode=require"
   
   # Data to fetch from AWS Secrets Manager (credentials only)
   dataFrom:

--- a/infra/helm/mosaic-life/templates/external-secrets.yaml
+++ b/infra/helm/mosaic-life/templates/external-secrets.yaml
@@ -23,8 +23,8 @@ spec:
       engineVersion: v2
       data:
         # Construct the full DB_URL from individual secret fields with SSL mode required for RDS
-        # Note: Using ssl=require for asyncpg compatibility (app converts psycopg -> asyncpg)
-        DB_URL: "postgresql+psycopg://{{ "{{ .username }}" }}:{{ "{{ .password }}" }}@{{ "{{ .host }}" }}:{{ "{{ .port }}" }}/{{ "{{ .dbname }}" }}?ssl=require"
+        # Note: Using sslmode=require for psycopg3 compatibility (app converts psycopg -> asyncpg)
+        DB_URL: "postgresql+psycopg://{{ "{{ .username }}" }}:{{ "{{ .password }}" }}@{{ "{{ .host }}" }}:{{ "{{ .port }}" }}/{{ "{{ .dbname }}" }}?sslmode=require"
   data:
     - secretKey: username
       remoteRef:


### PR DESCRIPTION
The database migrations use psycopg3 (sync driver) which requires sslmode=require parameter, not ssl=require. The previous change to ssl=require was based on asyncpg requirements, but migrations run before the driver conversion happens in the application code.

This fixes migration failures in both staging and production: psycopg.ProgrammingError: invalid connection option "ssl"

The application runtime correctly converts postgresql+psycopg:// to postgresql+asyncpg:// which uses ssl=require, but migrations need the sslmode parameter for psycopg3 compatibility.