### PR TITLE
fix(litellm): use valid ghcr database image tag

### DIFF
--- a/docs/plans/2026-03-07-litellm-implementation-plan.md
+++ b/docs/plans/2026-03-07-litellm-implementation-plan.md
@@ -63,7 +63,7 @@ maintainers:
 # infra/helm/litellm/values.yaml
 image:
   repository: ghcr.io/berriai/litellm-database
-  tag: "main-v1.72.0"
+  tag: "main-stable"
   pullPolicy: IfNotPresent
 
 replicaCount: 1
@@ -760,7 +760,9 @@ Add the following service block after the `neptune-local` service (before the `d
 ```yaml
   # LiteLLM AI Proxy
   litellm:
-    image: ghcr.io/berriai/litellm-database:main-v1.72.0
+    image: ghcr.io/berriai/litellm-database:main-stable
+
+  Execution note: the originally planned tag `main-v1.72.0` was not present in GHCR at deployment time. The implemented configuration uses `ghcr.io/berriai/litellm-database:main-stable`, which was verified to exist.
     ports:
       - "14000:4000"
     environment:

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -134,7 +134,7 @@ services:
 
   # LiteLLM AI Proxy
   litellm:
-    image: ghcr.io/berriai/litellm-database:main-v1.72.0
+    image: ghcr.io/berriai/litellm-database:main-stable
     ports:
       - "14000:4000"
     environment:

--- a/infra/helm/litellm/values.yaml
+++ b/infra/helm/litellm/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/berriai/litellm-database
-  tag: "main-v1.72.0"
+  tag: "main-stable"
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
## Summary
- switch LiteLLM to a pullable GHCR database image tag
- update local compose to use the same valid image tag
- note the deployment-time image correction in the implementation plan

## Verification
- docker manifest inspect ghcr.io/berriai/litellm-database:main-stable
- helm lint infra/helm/litellm/
- helm template litellm infra/helm/litellm/ --namespace aiservices | grep -A 2 'image:'
- docker compose -f infra/compose/docker-compose.yml config --services