### PR TITLE
fix(litellm): allow prisma cache on read-only rootfs

### DIFF
--- a/infra/helm/litellm/templates/deployment.yaml
+++ b/infra/helm/litellm/templates/deployment.yaml
@@ -49,6 +49,12 @@ spec:
                 secretKeyRef:
                   name: litellm-credentials
                   key: DATABASE_URL
+            - name: XDG_CACHE_HOME
+              value: /app/cache
+            - name: PRISMA_BINARY_CACHE_DIR
+              value: /app/cache/prisma-python/binaries
+            - name: LITELLM_MIGRATION_DIR
+              value: /app/migrations
           livenessProbe:
             httpGet:
               path: /health/liveliness
@@ -74,11 +80,19 @@ spec:
               mountPath: /app/config.yaml
               subPath: config.yaml
               readOnly: true
+            - name: cache
+              mountPath: /app/cache
+            - name: migrations
+              mountPath: /app/migrations
             - name: tmp
               mountPath: /tmp
       volumes:
         - name: config
           configMap:
             name: litellm-config
+        - name: cache
+          emptyDir: {}
+        - name: migrations
+          emptyDir: {}
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
## Summary
- add writable cache and migration directories for LiteLLM Prisma startup
- set LiteLLM cache and migration env vars for read-only filesystem deployments
- keep the hardened container security posture while allowing startup migrations

## Verification
- helm lint infra/helm/litellm/
- helm template litellm infra/helm/litellm/ --namespace aiservices | grep -E 'XDG_CACHE_HOME|PRISMA_BINARY_CACHE_DIR|LITELLM_MIGRATION_DIR|/app/cache|/app/migrations'