### PR TITLE
fix(litellm): disable pod prisma schema updates

### DIFF
--- a/infra/helm/litellm/templates/configmap.yaml
+++ b/infra/helm/litellm/templates/configmap.yaml
@@ -61,6 +61,7 @@ data:
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       database_url: os.environ/DATABASE_URL
+      disable_prisma_schema_update: true
       store_model_in_db: false
       disable_spend_logs: false
       proxy_batch_write_at: 10


### PR DESCRIPTION
This is to address a bug in the provisioning. We will eventually have to create a separate Kubernetes job to perform the upgrade explicitly