### PR TITLE
fix(litellm): Creating temporary mount for prisma cache

### DIFF
--- a/infra/helm/litellm/templates/configmap.yaml
+++ b/infra/helm/litellm/templates/configmap.yaml
@@ -61,7 +61,6 @@ data:
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       database_url: os.environ/DATABASE_URL
-      disable_prisma_schema_update: true
       store_model_in_db: false
       disable_spend_logs: false
       proxy_batch_write_at: 10

--- a/infra/helm/litellm/templates/deployment.yaml
+++ b/infra/helm/litellm/templates/deployment.yaml
@@ -68,8 +68,6 @@ spec:
               value: "true"
             - name: HOME
               value: /root
-            - name: DISABLE_SCHEMA_UPDATE
-              value: "true"
             - name: AWS_STS_REGIONAL_ENDPOINTS
               value: regional
             - name: AWS_DEFAULT_REGION


### PR DESCRIPTION
Prisma is hardcoded to use /root/.cache so this change will ensure there is a writable volume mounted there. 