### PR TITLE
fix: add LiteLLM External Secret and LITELLM_API_KEY injection to core-api deployment

### DIFF
--- a/infra/helm/mosaic-life/templates/core-api-deployment.yaml
+++ b/infra/helm/mosaic-life/templates/core-api-deployment.yaml
@@ -57,6 +57,14 @@ spec:
         {{- if .Values.coreApi.extraEnv }}
         {{- toYaml .Values.coreApi.extraEnv | nindent 8 }}
         {{- end }}
+        {{- /* Inject LiteLLM API key from External Secret if configured */ -}}
+        {{- if .Values.externalSecrets.litellm.secretKey }}
+        - name: LITELLM_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: litellm-api-key
+              key: LITELLM_API_KEY
+        {{- end }}
         {{- if .Values.coreApi.envFrom }}
         envFrom:
         {{- toYaml .Values.coreApi.envFrom | nindent 8 }}

--- a/infra/helm/mosaic-life/templates/external-secrets.yaml
+++ b/infra/helm/mosaic-life/templates/external-secrets.yaml
@@ -147,4 +147,31 @@ spec:
         key: {{ .Values.externalSecrets.neptune.secretKey }}
         property: env_prefix
 {{- end }}
+{{- if .Values.externalSecrets.litellm.secretKey }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: litellm-api-key
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mosaic-life.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind }}
+  target:
+    name: litellm-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: LITELLM_API_KEY
+      remoteRef:
+        key: {{ .Values.externalSecrets.litellm.secretKey }}
+        property: api_key
+{{- end }}
 {{- end }}

--- a/infra/helm/mosaic-life/values.yaml
+++ b/infra/helm/mosaic-life/values.yaml
@@ -399,6 +399,9 @@ externalSecrets:
     property: "token"
   neptune:
     secretKey: "mosaic/prod/neptune/connection"
+  litellm:
+    # Optional: set to AWS Secrets Manager path containing {api_key: "<virtual key>"}
+    secretKey: ""
 
 # Entity Backfill Job (one-time graph population)
 entityBackfill:


### PR DESCRIPTION
## Summary

Adds the missing infrastructure pieces to wire `LITELLM_API_KEY` into core-api pods, required for the LiteLLM integration to work in production.

### Root Cause (from staging incident 2026-03-08)

Helm does **not** deep-merge arrays — the per-environment `values.yaml` files in the gitops repo fully replace the base `coreApi.env` list. `LITELLM_BASE_URL` was present in the base chart but not being injected because the env arrays in the gitops repo don't include it. Additionally, `LITELLM_API_KEY` had no injection mechanism at all.

### Changes

**`infra/helm/mosaic-life/templates/external-secrets.yaml`**
- New `ExternalSecret` resource (`litellm-api-key`) that reads `api_key` from `mosaic/<env>/litellm/api-key` in AWS Secrets Manager
- Rendered only when `externalSecrets.litellm.secretKey` is set

**`infra/helm/mosaic-life/templates/core-api-deployment.yaml`**
- Injects `LITELLM_API_KEY` via `secretKeyRef` → `litellm-api-key` secret when the external secret is configured

**`infra/helm/mosaic-life/values.yaml`**
- Adds `externalSecrets.litellm.secretKey: ""` default (empty = disabled, no External Secret rendered)

### Operational steps completed (not in this PR)

- AWS SM secrets created:
  - `mosaic/staging/litellm/api-key` — virtual key `core-api-staging`
  - `mosaic/prod/litellm/api-key` — virtual key `core-api-prod`
- Gitops repo updated for both environments:
  - `environments/staging/values.yaml` — `LITELLM_BASE_URL`, `AI_LLM_PROVIDER`, `AI_EMBEDDING_PROVIDER`, `externalSecrets.litellm.secretKey`
  - `environments/prod/values.yaml` — same additions

Staging is fully working after these changes. Merging this PR will allow the prod ArgoCD app (which tracks `main`) to deploy the ExternalSecret and `LITELLM_API_KEY` injection.