### PR TITLE
Sync develop into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 build/
 .next/
 out/
-
+nohup.out
 # Environment variables
 .env
 .env.local

--- a/infra/argocd/applications/prerender-prod.yaml
+++ b/infra/argocd/applications/prerender-prod.yaml
@@ -15,12 +15,12 @@ spec:
     path: infra/helm/prerender
     helm:
       values: |
-        replicaCount: 0
+        replicaCount: 1
         config:
           allowedDomains: "mosaiclife.me,api.mosaiclife.me"
         autoscaling:
           enabled: false
-          minReplicas: 0
+          minReplicas: 1
           maxReplicas: 5
 
   destination:

--- a/infra/argocd/applications/prerender-prod.yaml
+++ b/infra/argocd/applications/prerender-prod.yaml
@@ -15,12 +15,12 @@ spec:
     path: infra/helm/prerender
     helm:
       values: |
-        replicaCount: 2
+        replicaCount: 0
         config:
           allowedDomains: "mosaiclife.me,api.mosaiclife.me"
         autoscaling:
-          enabled: true
-          minReplicas: 2
+          enabled: false
+          minReplicas: 0
           maxReplicas: 5
 
   destination:

--- a/justfile
+++ b/justfile
@@ -938,6 +938,94 @@ argocd-apply-staging:
     kubectl apply -f infra/argocd/applications/mosaic-life-staging.yaml
     @echo "✓ Staging application configured"
 
+# Show staging ArgoCD apps and live namespace resources
+stage-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    APPS=(mosaic-life-staging docs-staging prerender-staging)
+    echo "Staging ArgoCD applications:"
+    kubectl get applications -n argocd "${APPS[@]}" -o wide --ignore-not-found=true
+    echo ""
+    echo "Staging namespace resources:"
+    kubectl get pods,deploy,svc,ingress,hpa,pdb,externalsecret,secretstore -n mosaic-staging --ignore-not-found=true
+
+# Spin down staging by deleting only staging ArgoCD applications
+stage-down confirm="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    APPS=(mosaic-life-staging docs-staging prerender-staging)
+    if [ "{{confirm}}" != "mosaic-staging" ]; then
+      echo "Refusing to spin down staging without explicit confirmation."
+      echo "This deletes only these ArgoCD Applications in namespace argocd:"
+      printf '  - %s\n' "${APPS[@]}"
+      echo ""
+      echo "Run: just stage-down mosaic-staging"
+      exit 1
+    fi
+
+    echo "Spinning down staging ArgoCD applications:"
+    printf '  - %s\n' "${APPS[@]}"
+    echo ""
+    for app in "${APPS[@]}"; do
+      kubectl delete application -n argocd "$app" --ignore-not-found=true --wait=false
+    done
+
+    echo ""
+    echo "Waiting for ArgoCD application deletion and resource pruning..."
+    for app in "${APPS[@]}"; do
+      if kubectl get application -n argocd "$app" >/dev/null 2>&1; then
+        kubectl wait --for=delete "application/$app" -n argocd --timeout=10m
+      fi
+    done
+
+    echo ""
+    echo "Remaining resources in mosaic-staging:"
+    kubectl get pods,deploy,svc,ingress,hpa,pdb,externalsecret,secretstore -n mosaic-staging --ignore-not-found=true
+    echo ""
+    echo "✓ Staging spin-down requested. Production applications were not touched."
+
+# Restore staging ArgoCD applications
+stage-up:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    APPS=(mosaic-life-staging docs-staging prerender-staging)
+    echo "Restoring staging ArgoCD applications..."
+    kubectl apply -f infra/argocd/applications/mosaic-life-staging.yaml
+    kubectl apply -f infra/argocd/applications/docs-staging.yaml
+    kubectl apply -f infra/argocd/applications/prerender-staging.yaml
+
+    if command -v argocd >/dev/null 2>&1; then
+      echo ""
+      echo "Triggering ArgoCD sync for staging applications..."
+      for app in "${APPS[@]}"; do
+        if ! argocd app sync "$app" --async; then
+          echo "Warning: argocd sync failed for $app; automated sync may still reconcile it."
+        fi
+      done
+    else
+      echo ""
+      echo "argocd CLI not found; relying on automated sync."
+    fi
+
+    echo ""
+    echo "✓ Staging restore requested."
+    echo "Monitor with: just stage-wait-up"
+
+# Wait for staging ArgoCD apps to be synced and healthy
+stage-wait-up timeout="600":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    APPS=(mosaic-life-staging docs-staging prerender-staging)
+    if command -v argocd >/dev/null 2>&1; then
+      for app in "${APPS[@]}"; do
+        argocd app wait "$app" --sync --health --timeout {{timeout}}
+      done
+    else
+      echo "argocd CLI is required for sync/health waiting."
+      exit 1
+    fi
+    echo "✓ Staging applications are synced and healthy."
+
 # Apply Graph Explorer production ArgoCD application
 argocd-apply-graph-explorer-prod:
     kubectl apply -f infra/argocd/applications/graph-explorer-prod.yaml


### PR DESCRIPTION
This PR syncs the current `develop` branch into `main`.

Included changes:
- scale `prerender-prod` down to a single replica and disable autoscaling for that standalone ArgoCD application
- ignore `nohup.out` so local ArgoCD UI port-forward logs are not tracked
- include the staging lifecycle command updates currently on `develop`

Why:
- keep `main` aligned with the current validated infrastructure state in `develop`
- preserve the production prerender fix in the mainline branch
