### PR TITLE
feat(story-responses): turn a long response into its own story

### DIFF
--- a/apps/web/src/features/story-responses/api/responses.ts
+++ b/apps/web/src/features/story-responses/api/responses.ts
@@ -3,6 +3,12 @@
 // services/core-api/app/schemas/story_response.py exactly.
 import { apiGet, apiPost, apiPatch, apiDelete } from '@/lib/api/client';
 
+export interface ConvertedStorySummary {
+  id: string;
+  title: string;
+  legacy_id: string | null;
+}
+
 export interface StoryResponseItem {
   id: string;
   story_id: string;
@@ -14,6 +20,22 @@ export interface StoryResponseItem {
   created_at: string;
   /** Non-null when the response has been edited since creation. */
   edited_at: string | null;
+  /**
+   * Non-null when this response was converted into a standalone story; the
+   * response renders as a non-editable note linking to it (see
+   * openspec/changes/response-to-story).
+   */
+  converted_story_id: string | null;
+  /** Summary of the converted story, populated when `converted_story_id` is set. */
+  converted_story: ConvertedStorySummary | null;
+  /** Non-null once the response's author has dismissed the "make this a story" offer. */
+  offer_dismissed_at: string | null;
+  /**
+   * True when the story author has hidden this converted note from other
+   * viewers. Server-side list filtering means only the note's own author
+   * will ever actually receive `hidden: true`.
+   */
+  hidden: boolean;
 }
 
 export interface StoryResponseListResponse {
@@ -57,4 +79,21 @@ export async function deleteResponse(
   responseId: string,
 ): Promise<void> {
   return apiDelete(`/api/stories/${storyId}/responses/${responseId}`);
+}
+
+export async function dismissOffer(
+  storyId: string,
+  responseId: string,
+): Promise<StoryResponseItem> {
+  return apiPost<StoryResponseItem>(
+    `/api/stories/${storyId}/responses/${responseId}/dismiss-offer`,
+  );
+}
+
+// Story-author "hide this converted note" endpoint — see useHideResponse.
+export async function hideResponse(
+  storyId: string,
+  responseId: string,
+): Promise<StoryResponseItem> {
+  return apiPost<StoryResponseItem>(`/api/stories/${storyId}/responses/${responseId}/hide`);
 }

--- a/apps/web/src/features/story-responses/components/ResponseItem.test.tsx
+++ b/apps/web/src/features/story-responses/components/ResponseItem.test.tsx
@@ -6,16 +6,29 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ResponseItem from './ResponseItem';
 import type { StoryResponseItem } from '@/features/story-responses/api/responses';
 
+const apiPost = vi.fn();
 const apiPatch = vi.fn();
 const apiDelete = vi.fn();
 
 vi.mock('@/lib/api/client', () => ({
   apiGet: vi.fn(),
-  apiPost: vi.fn(),
+  apiPost: (...args: unknown[]) => apiPost(...args),
   apiPatch: (...args: unknown[]) => apiPatch(...args),
   apiDelete: (...args: unknown[]) => apiDelete(...args),
   ApiError: class ApiError extends Error {},
 }));
+
+// Spy on navigation without losing MemoryRouter/Link's real behavior — the
+// "take the offer" flow is asserted via the navigate call, and the
+// converted-note link is asserted via its rendered href.
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 const baseResponse: StoryResponseItem = {
   id: 'response-1',
@@ -27,6 +40,10 @@ const baseResponse: StoryResponseItem = {
   body: 'I remember this fondly.',
   created_at: new Date(Date.now() - 60_000).toISOString(),
   edited_at: null,
+  converted_story_id: null,
+  converted_story: null,
+  offer_dismissed_at: null,
+  hidden: false,
 };
 
 function renderItem(props: Partial<React.ComponentProps<typeof ResponseItem>> = {}) {
@@ -36,9 +53,12 @@ function renderItem(props: Partial<React.ComponentProps<typeof ResponseItem>> = 
       <MemoryRouter>
         <ResponseItem
           storyId="story-1"
+          legacyId="legacy-1"
+          sourceStoryId="story-1"
           response={baseResponse}
           currentUserId="user-2"
           canModerate={false}
+          isStoryAuthor={false}
           {...props}
         />
       </MemoryRouter>
@@ -148,5 +168,164 @@ describe('ResponseItem', () => {
     await user.click(screen.getByRole('button', { name: /cancel/i }));
 
     expect(apiDelete).not.toHaveBeenCalled();
+  });
+});
+
+// A response with more than four `.?!`-terminated sentences — see
+// isLongResponse.ts's threshold. Five short sentences comfortably clears it.
+const LONG_BODY = 'One. Two. Three. Four. Five.';
+
+describe('ResponseItem — "make it a story" offer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the offer for the author’s own long, undismissed, unconverted response', () => {
+    renderItem({ response: { ...baseResponse, body: LONG_BODY } });
+
+    expect(screen.getByTestId('convert-to-story-offer')).toBeInTheDocument();
+    expect(screen.getByText(/this sounds like its own story/i)).toBeInTheDocument();
+  });
+
+  it('shows no offer for the author’s own short response', () => {
+    renderItem();
+
+    expect(screen.queryByTestId('convert-to-story-offer')).not.toBeInTheDocument();
+  });
+
+  it('shows no offer on another member’s long response', () => {
+    renderItem({
+      response: { ...baseResponse, body: LONG_BODY },
+      currentUserId: 'user-3',
+    });
+
+    expect(screen.queryByTestId('convert-to-story-offer')).not.toBeInTheDocument();
+  });
+
+  it('shows no offer once it has been dismissed for that response', () => {
+    renderItem({
+      response: { ...baseResponse, body: LONG_BODY, offer_dismissed_at: new Date().toISOString() },
+    });
+
+    expect(screen.queryByTestId('convert-to-story-offer')).not.toBeInTheDocument();
+  });
+
+  it('shows no offer on a converted response, even if long', () => {
+    renderItem({
+      response: {
+        ...baseResponse,
+        body: LONG_BODY,
+        converted_story_id: 'story-9',
+        converted_story: { id: 'story-9', title: 'A Grown Story', legacy_id: 'legacy-9' },
+      },
+    });
+
+    expect(screen.queryByTestId('convert-to-story-offer')).not.toBeInTheDocument();
+  });
+
+  it('shows no offer on an optimistic (temp-) row, even if long', () => {
+    renderItem({
+      response: { ...baseResponse, id: 'temp-123', body: LONG_BODY },
+    });
+
+    expect(screen.queryByTestId('convert-to-story-offer')).not.toBeInTheDocument();
+  });
+
+  it('navigates to the new-story page seeded with the raw body and source response id when taking the offer', async () => {
+    const user = userEvent.setup();
+    renderItem({ response: { ...baseResponse, body: LONG_BODY } });
+
+    await user.click(screen.getByRole('button', { name: /make it a story/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/legacy/legacy-1/story/new', {
+      state: { seedBody: LONG_BODY, sourceResponseId: 'response-1' },
+    });
+  });
+
+  it('seeds a plain-text body verbatim, without applying any markdown formatting, when taking the offer', async () => {
+    const user = userEvent.setup();
+    const rawBody = '**Bold** intro. # Heading line. Third sentence. Fourth sentence. Fifth.';
+    renderItem({ response: { ...baseResponse, body: rawBody } });
+
+    await user.click(screen.getByRole('button', { name: /make it a story/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/legacy/legacy-1/story/new', {
+      state: { seedBody: rawBody, sourceResponseId: 'response-1' },
+    });
+  });
+});
+
+describe('ResponseItem — converted note state', () => {
+  const convertedResponse: StoryResponseItem = {
+    ...baseResponse,
+    body: 'This is the original body, now retired in favor of the note.',
+    converted_story_id: 'story-9',
+    converted_story: { id: 'story-9', title: 'A Grown Story', legacy_id: 'legacy-9' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the "Turned this into a story" link instead of the original body', () => {
+    renderItem({ response: convertedResponse });
+
+    const link = screen.getByRole('link', { name: /turned this into a story/i });
+    expect(link).toHaveAttribute('href', '/legacy/legacy-9/story/story-9');
+    expect(screen.queryByText(convertedResponse.body)).not.toBeInTheDocument();
+  });
+
+  it('shows no edit affordance for a converted note, even for its own author', () => {
+    renderItem({ response: convertedResponse, currentUserId: 'user-2' });
+
+    expect(screen.queryByRole('button', { name: /edit response/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps the delete affordance for the note’s own author', () => {
+    renderItem({ response: convertedResponse, currentUserId: 'user-2' });
+
+    expect(screen.getByRole('button', { name: /delete response/i })).toBeInTheDocument();
+  });
+});
+
+describe('ResponseItem — story-author "hide note" affordance', () => {
+  const convertedResponse: StoryResponseItem = {
+    ...baseResponse,
+    converted_story_id: 'story-9',
+    converted_story: { id: 'story-9', title: 'A Grown Story', legacy_id: 'legacy-9' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the hide affordance to the story author on a converted note', () => {
+    renderItem({ response: convertedResponse, currentUserId: 'user-1', isStoryAuthor: true });
+
+    expect(screen.getByRole('button', { name: /hide note/i })).toBeInTheDocument();
+  });
+
+  it('hides no affordance from a non-story-author viewer, even on a converted note', () => {
+    renderItem({ response: convertedResponse, currentUserId: 'user-1', isStoryAuthor: false });
+
+    expect(screen.queryByRole('button', { name: /hide note/i })).not.toBeInTheDocument();
+  });
+
+  it('shows no hide affordance on an ordinary (non-note) response, even for the story author', () => {
+    renderItem({ response: baseResponse, currentUserId: 'user-1', isStoryAuthor: true });
+
+    expect(screen.queryByRole('button', { name: /hide note/i })).not.toBeInTheDocument();
+  });
+
+  it('calls the hide endpoint when the story author clicks hide', async () => {
+    const user = userEvent.setup();
+    apiPost.mockResolvedValue({ ...convertedResponse, hidden: false });
+
+    renderItem({ response: convertedResponse, currentUserId: 'user-1', isStoryAuthor: true });
+    await user.click(screen.getByRole('button', { name: /hide note/i }));
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('/api/stories/story-1/responses/response-1/hide');
+    });
   });
 });

--- a/apps/web/src/features/story-responses/components/ResponseItem.tsx
+++ b/apps/web/src/features/story-responses/components/ResponseItem.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
-import { Pencil, Trash2, Loader2, X, Check } from 'lucide-react';
+import { Pencil, Trash2, Loader2, X, Check, EyeOff } from 'lucide-react';
 import UserLink from '@/components/UserLink';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -16,11 +17,28 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import PlainTextBody from '@/features/story-responses/utils/PlainTextBody';
-import { useUpdateResponse, useDeleteResponse } from '@/features/story-responses/hooks/useResponses';
+import { isLongResponse } from '@/features/story-responses/utils/isLongResponse';
+import {
+  useUpdateResponse,
+  useDeleteResponse,
+  useDismissOffer,
+  useHideResponse,
+} from '@/features/story-responses/hooks/useResponses';
 import type { StoryResponseItem } from '@/features/story-responses/api/responses';
 
 export interface ResponseItemProps {
   storyId: string;
+  /** Legacy the responded-to story belongs to — used to seed-and-navigate to
+   * `/legacy/:legacyId/story/new` when the author takes the "make it a story" offer. */
+  legacyId: string;
+  /**
+   * The id of the story this response belongs to. Today this is always the
+   * same value as `storyId` (responses only ever render on the story they
+   * were posted against); it is threaded through as its own explicitly-named
+   * prop so later work (converted-note backlink rendering) has an
+   * unambiguous name to reach for.
+   */
+  sourceStoryId: string;
   response: StoryResponseItem;
   /** Current viewer's user id — undefined when not authenticated. */
   currentUserId?: string;
@@ -30,14 +48,25 @@ export interface ResponseItemProps {
    * requirement; advocate/admirer never get this).
    */
   canModerate: boolean;
+  /**
+   * True when the viewer is the author of the story these responses belong
+   * to — gates the "hide note" affordance, which per the story-responses
+   * spec is scoped to converted notes only (not general response
+   * moderation, which is deferred to a separate change).
+   */
+  isStoryAuthor: boolean;
 }
 
 export default function ResponseItem({
   storyId,
+  legacyId,
+  sourceStoryId,
   response,
   currentUserId,
   canModerate,
+  isStoryAuthor,
 }: ResponseItemProps) {
+  const navigate = useNavigate();
   // Mirrors the `response` prop, but is also updated directly from a
   // successful edit's response body. The list view (ResponsesSection)
   // re-renders this component with fresh props once its query cache is
@@ -54,11 +83,31 @@ export default function ResponseItem({
 
   const updateResponse = useUpdateResponse(storyId);
   const deleteResponse = useDeleteResponse(storyId);
+  const dismissOfferMutation = useDismissOffer(storyId);
+  const hideResponseMutation = useHideResponse(storyId);
 
   const isOwnResponse = !!currentUserId && displayResponse.user_id === currentUserId;
-  const canEdit = isOwnResponse;
+  // A converted note is never editable — the backend rejects PATCH on a
+  // converted response with 400 (see story_response.py::update_response).
+  const isNote = displayResponse.converted_story_id != null;
+  const canEdit = isOwnResponse && !isNote;
   const canDelete = isOwnResponse || canModerate;
+  // Story-author "hide from others" moderation is scoped to converted notes
+  // only (see D5 / R2 in the response-to-story design) — never on ordinary
+  // responses.
+  const canHide = isStoryAuthor && isNote;
   const isTemp = displayResponse.id.startsWith('temp-');
+  // Gentle, dismissible offer to turn a long response into its own story —
+  // author-only, never on a response that's already a converted note, and
+  // never on the optimistic (not-yet-persisted) row. Suppressed while
+  // actively editing since the row's layout changes underneath it.
+  const showConvertOffer =
+    isOwnResponse &&
+    !isTemp &&
+    !isEditing &&
+    isLongResponse(displayResponse.body) &&
+    !displayResponse.offer_dismissed_at &&
+    displayResponse.converted_story_id == null;
 
   const timeAgo = formatDistanceToNow(new Date(displayResponse.created_at), { addSuffix: true });
 
@@ -99,8 +148,43 @@ export default function ResponseItem({
     });
   };
 
+  const handleTakeOffer = () => {
+    navigate(`/legacy/${legacyId}/story/new`, {
+      state: { seedBody: displayResponse.body, sourceResponseId: displayResponse.id },
+    });
+  };
+
+  const handleDismissOffer = () => {
+    dismissOfferMutation.mutate(displayResponse.id, {
+      onSuccess: (updated) => setDisplayResponse(updated),
+      onError: () => setError('Failed to dismiss. Please try again.'),
+    });
+  };
+
+  const handleHide = () => {
+    hideResponseMutation.mutate(displayResponse.id, {
+      onSuccess: (updated) => setDisplayResponse(updated),
+      onError: () => setError('Failed to hide this note. Please try again.'),
+    });
+  };
+
+  // Populated once the response has been converted into a story; used to
+  // link the note. `converted_story` can in principle be null while
+  // `converted_story_id` is still set (e.g. a stale in-flight cache read) —
+  // guarded defensively so this never throws, even though in steady state
+  // the FK's ON DELETE SET NULL means the two are always consistent.
+  const convertedStoryPath =
+    isNote && displayResponse.converted_story && displayResponse.converted_story.legacy_id
+      ? `/legacy/${displayResponse.converted_story.legacy_id}/story/${displayResponse.converted_story.id}`
+      : null;
+
   return (
-    <div className="flex gap-3 py-3" data-testid="response-item" aria-busy={isTemp}>
+    <div
+      className="flex gap-3 py-3"
+      data-testid="response-item"
+      data-source-story-id={sourceStoryId}
+      aria-busy={isTemp}
+    >
       <UserLink
         username={displayResponse.user_username}
         displayName={displayResponse.user_name}
@@ -158,6 +242,19 @@ export default function ResponseItem({
               </Button>
             </div>
           </div>
+        ) : isNote ? (
+          <p className="mt-1 text-sm" data-testid="converted-note">
+            {convertedStoryPath ? (
+              <Link
+                to={convertedStoryPath}
+                className="font-medium text-neutral-500 underline underline-offset-2 hover:text-neutral-800"
+              >
+                Turned this into a story →
+              </Link>
+            ) : (
+              <span className="text-neutral-400">Turned this into a story.</span>
+            )}
+          </p>
         ) : (
           <PlainTextBody
             text={displayResponse.body}
@@ -170,9 +267,39 @@ export default function ResponseItem({
             {error}
           </p>
         )}
+
+        {showConvertOffer && (
+          <div
+            className="mt-2 flex items-center gap-2 text-xs text-neutral-400"
+            data-testid="convert-to-story-offer"
+          >
+            <span>This sounds like its own story.</span>
+            <button
+              type="button"
+              onClick={handleTakeOffer}
+              className="font-medium text-neutral-500 underline underline-offset-2 hover:text-neutral-800"
+            >
+              Make it a story
+            </button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="size-5 p-0 text-neutral-300 hover:text-neutral-600"
+              onClick={handleDismissOffer}
+              disabled={dismissOfferMutation.isPending}
+              aria-label="Dismiss story suggestion"
+            >
+              {dismissOfferMutation.isPending ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <X className="size-3" />
+              )}
+            </Button>
+          </div>
+        )}
       </div>
 
-      {!isEditing && !isTemp && (canEdit || canDelete) && (
+      {!isEditing && !isTemp && (canEdit || canDelete || canHide) && (
         <div className="flex items-start gap-1 shrink-0">
           {canEdit && (
             <Button
@@ -215,6 +342,22 @@ export default function ResponseItem({
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
+          )}
+          {canHide && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="size-7 p-0 text-neutral-400 hover:text-neutral-700"
+              onClick={handleHide}
+              disabled={hideResponseMutation.isPending}
+              aria-label="Hide note"
+            >
+              {hideResponseMutation.isPending ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <EyeOff className="size-3.5" />
+              )}
+            </Button>
           )}
         </div>
       )}

--- a/apps/web/src/features/story-responses/components/ResponsesSection.test.tsx
+++ b/apps/web/src/features/story-responses/components/ResponsesSection.test.tsx
@@ -33,7 +33,15 @@ function renderSection(props: Partial<React.ComponentProps<typeof ResponsesSecti
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
-        <ResponsesSection storyId="story-1" currentUserId="user-1" canModerate={false} {...props} />
+        <ResponsesSection
+          storyId="story-1"
+          legacyId="legacy-1"
+          sourceStoryId="story-1"
+          currentUserId="user-1"
+          canModerate={false}
+          isStoryAuthor={false}
+          {...props}
+        />
       </MemoryRouter>
     </QueryClientProvider>,
   );

--- a/apps/web/src/features/story-responses/components/ResponsesSection.tsx
+++ b/apps/web/src/features/story-responses/components/ResponsesSection.tsx
@@ -7,17 +7,36 @@ import { useResponsesList, useCreateResponse } from '@/features/story-responses/
 
 export interface ResponsesSectionProps {
   storyId: string;
+  /** Legacy the story belongs to — threaded down to `ResponseItem` for its
+   * "make it a story" offer, which navigates to `/legacy/:legacyId/story/new`. */
+  legacyId: string;
+  /**
+   * The id of the story these responses belong to. Today always equal to
+   * `storyId`; threaded through as its own explicitly-named prop so later
+   * work (converted-note backlink rendering) has an unambiguous name to
+   * reach for.
+   */
+  sourceStoryId: string;
   currentUserId?: string;
   /** Legacy creator/admin — can remove other members' responses. */
   canModerate: boolean;
+  /**
+   * True when the viewer is the author of the story these responses belong
+   * to — gates the "hide note" affordance on converted notes (story-author
+   * moderation is scoped to notes only; see response-to-story spec).
+   */
+  isStoryAuthor: boolean;
   /** Authoritative count from the story record, shown in the section heading. */
   responseCount?: number;
 }
 
 export default function ResponsesSection({
   storyId,
+  legacyId,
+  sourceStoryId,
   currentUserId,
   canModerate,
+  isStoryAuthor,
   responseCount,
 }: ResponsesSectionProps) {
   const [draft, setDraft] = useState('');
@@ -100,9 +119,12 @@ export default function ResponsesSection({
             <ResponseItem
               key={response.id}
               storyId={storyId}
+              legacyId={legacyId}
+              sourceStoryId={sourceStoryId}
               response={response}
               currentUserId={currentUserId}
               canModerate={canModerate}
+              isStoryAuthor={isStoryAuthor}
             />
           ))
         )}

--- a/apps/web/src/features/story-responses/hooks/useResponses.ts
+++ b/apps/web/src/features/story-responses/hooks/useResponses.ts
@@ -13,6 +13,8 @@ import {
   createResponse,
   updateResponse,
   deleteResponse,
+  dismissOffer,
+  hideResponse,
   type StoryResponseItem,
   type StoryResponseListResponse,
 } from '@/features/story-responses/api/responses';
@@ -96,6 +98,10 @@ export function useCreateResponse(storyId: string) {
         body,
         created_at: new Date().toISOString(),
         edited_at: null,
+        converted_story_id: null,
+        converted_story: null,
+        offer_dismissed_at: null,
+        hidden: false,
       };
 
       queryClient.setQueryData<ResponsesPageData>(responseKeys.list(storyId), (old) => {
@@ -160,6 +166,98 @@ export function useUpdateResponse(storyId: string) {
           items.map((item) => (item.id === updated.id ? updated : item)),
         ),
       );
+    },
+  });
+}
+
+/** Mirrors `useUpdateResponse`'s optimistic-update / reconcile-on-success shape. */
+export function useDismissOffer(storyId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    StoryResponseItem,
+    Error,
+    string,
+    { previousData?: ResponsesPageData }
+  >({
+    mutationFn: (responseId: string) => dismissOffer(storyId, responseId),
+    onMutate: async (responseId) => {
+      await queryClient.cancelQueries({ queryKey: responseKeys.list(storyId) });
+      const previousData = queryClient.getQueryData<ResponsesPageData>(
+        responseKeys.list(storyId),
+      );
+      queryClient.setQueryData<ResponsesPageData>(responseKeys.list(storyId), (old) =>
+        updateCachedPages(old, (items) =>
+          items.map((item) =>
+            item.id === responseId
+              ? { ...item, offer_dismissed_at: new Date().toISOString() }
+              : item,
+          ),
+        ),
+      );
+      return { previousData };
+    },
+    onError: (_err, _responseId, context) => {
+      if (context) {
+        queryClient.setQueryData(responseKeys.list(storyId), context.previousData);
+      }
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<ResponsesPageData>(responseKeys.list(storyId), (old) =>
+        updateCachedPages(old, (items) =>
+          items.map((item) => (item.id === updated.id ? updated : item)),
+        ),
+      );
+    },
+  });
+}
+
+/**
+ * Mirrors `useDismissOffer`'s optimistic-update / reconcile-on-success shape,
+ * but additionally invalidates the list query on success (`onSettled`):
+ * hiding a note can make the row disappear entirely for the *hiding*
+ * viewer's own view — the backend list filter excludes any response with
+ * `hidden_at` set unless the viewer is the note's own author, so a story
+ * author who isn't the note's own author will no longer see this row on the
+ * next fetch. Letting the invalidate-driven refetch re-run that server-side
+ * filter is simpler and more correct than trying to replicate it client-side.
+ */
+export function useHideResponse(storyId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    StoryResponseItem,
+    Error,
+    string,
+    { previousData?: ResponsesPageData }
+  >({
+    mutationFn: (responseId: string) => hideResponse(storyId, responseId),
+    onMutate: async (responseId) => {
+      await queryClient.cancelQueries({ queryKey: responseKeys.list(storyId) });
+      const previousData = queryClient.getQueryData<ResponsesPageData>(
+        responseKeys.list(storyId),
+      );
+      queryClient.setQueryData<ResponsesPageData>(responseKeys.list(storyId), (old) =>
+        updateCachedPages(old, (items) =>
+          items.map((item) => (item.id === responseId ? { ...item, hidden: true } : item)),
+        ),
+      );
+      return { previousData };
+    },
+    onError: (_err, _responseId, context) => {
+      if (context) {
+        queryClient.setQueryData(responseKeys.list(storyId), context.previousData);
+      }
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<ResponsesPageData>(responseKeys.list(storyId), (old) =>
+        updateCachedPages(old, (items) =>
+          items.map((item) => (item.id === updated.id ? updated : item)),
+        ),
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: responseKeys.list(storyId) });
     },
   });
 }

--- a/apps/web/src/features/story-responses/utils/isLongResponse.test.ts
+++ b/apps/web/src/features/story-responses/utils/isLongResponse.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { isLongResponse } from './isLongResponse';
+
+describe('isLongResponse', () => {
+  it('returns false for exactly four sentences', () => {
+    expect(isLongResponse('One. Two. Three. Four.')).toBe(false);
+  });
+
+  it('returns true for five sentences', () => {
+    expect(isLongResponse('One. Two. Three. Four. Five.')).toBe(true);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isLongResponse('')).toBe(false);
+  });
+
+  it('returns false for whitespace only', () => {
+    expect(isLongResponse('   \n  ')).toBe(false);
+  });
+
+  it('ignores trailing whitespace around the terminal punctuation', () => {
+    expect(isLongResponse('One.   Two.  Three. Four.   ')).toBe(false);
+    expect(isLongResponse('One.   Two.  Three. Four. Five.   ')).toBe(true);
+  });
+
+  it('counts a final sentence with no terminal punctuation', () => {
+    // Four proper sentences plus a fifth, unterminated fragment - still counts
+    // as five non-empty segments.
+    expect(isLongResponse('One. Two. Three. Four. And a fifth without punctuation')).toBe(true);
+  });
+
+  it('does not count doubled-up terminators as extra sentences', () => {
+    // "Wait..." + "Really?!" + two more should be four segments, not more,
+    // because consecutive terminators collapse via the `+` in the split regex.
+    expect(isLongResponse('Wait... Really?! One more. And another.')).toBe(false);
+  });
+
+  it('treats a single unterminated sentence as one, not long', () => {
+    expect(isLongResponse('Just one thought with no punctuation')).toBe(false);
+  });
+});

--- a/apps/web/src/features/story-responses/utils/isLongResponse.ts
+++ b/apps/web/src/features/story-responses/utils/isLongResponse.ts
@@ -1,0 +1,21 @@
+/**
+ * "Long response" signal used to decide whether to offer turning a response
+ * into its own standalone story (see openspec/changes/response-to-story).
+ *
+ * A response is "long" when it has more than four sentences (5+), counted by
+ * a simple `.?!`-terminator split. This is a length signal, not a quality
+ * judgement (per the change's non-goals), and is expected to occasionally
+ * miscount abbreviations, ellipses, or decimals — accepted for MVP. Isolated
+ * here in one testable place so the threshold/algorithm can be tuned later
+ * without touching callers.
+ */
+const LONG_RESPONSE_SENTENCE_THRESHOLD = 4;
+
+export function isLongResponse(body: string): boolean {
+  const sentenceCount = body
+    .split(/[.?!]+/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0).length;
+
+  return sentenceCount > LONG_RESPONSE_SENTENCE_THRESHOLD;
+}

--- a/apps/web/src/features/story/api/stories.ts
+++ b/apps/web/src/features/story/api/stories.ts
@@ -35,6 +35,13 @@ export interface StorySummary {
   reaction_smile_count: number;
 }
 
+/** Summary of a related story used for source/grown-from backlinks (see response-to-story). */
+export interface StoryBacklinkSummary {
+  id: string;
+  title: string;
+  legacy_id: string | null;
+}
+
 export interface StoryDetail {
   id: string;
   legacies: LegacyAssociation[];
@@ -50,6 +57,10 @@ export interface StoryDetail {
   version_count: number | null;  // null if not author
   has_draft: boolean | null;     // null if not author
   source_conversation_id: string | null;
+  /** This story's backlink to the story it grew out of, when it was created from a response on another story. */
+  source_story: StoryBacklinkSummary | null;
+  /** Other stories that grew out of a response left on this story (viewer-readable subset). */
+  grown_from_responses: StoryBacklinkSummary[];
   created_at: string;
   updated_at: string;
   favorite_count: number;
@@ -67,6 +78,8 @@ export interface CreateStoryInput {
   content: string;
   visibility?: 'public' | 'private' | 'personal';
   status?: 'draft' | 'published';
+  /** The response this story is converted from, if any (see response-to-story). */
+  source_response_id?: string;
 }
 
 export interface UpdateStoryInput {

--- a/apps/web/src/features/story/components/StoryBacklinks.test.tsx
+++ b/apps/web/src/features/story/components/StoryBacklinks.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import StoryBacklinks from './StoryBacklinks';
+import type { StoryBacklinkSummary } from '@/features/story/api/stories';
+
+function renderBacklinks(
+  props: Partial<React.ComponentProps<typeof StoryBacklinks>> = {},
+) {
+  return render(
+    <MemoryRouter>
+      <StoryBacklinks sourceStory={null} grownStories={[]} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+const sourceStory: StoryBacklinkSummary = {
+  id: 'story-source',
+  title: 'The Summer at the Lake',
+  legacy_id: 'legacy-1',
+};
+
+const grownStory: StoryBacklinkSummary = {
+  id: 'story-grown',
+  title: 'A Memory Worth Its Own Page',
+  legacy_id: 'legacy-1',
+};
+
+describe('StoryBacklinks', () => {
+  it('renders nothing when there is no source story and no grown stories', () => {
+    const { container } = renderBacklinks();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the source-story backlink and links to it correctly', () => {
+    renderBacklinks({ sourceStory });
+
+    expect(screen.getByTestId('source-story-backlink')).toBeInTheDocument();
+    expect(screen.getByText(/grew out of a memory on/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: sourceStory.title });
+    expect(link).toHaveAttribute('href', '/legacy/legacy-1/story/story-source');
+  });
+
+  it('renders each grown-from-responses entry and links to it correctly', () => {
+    const secondGrownStory: StoryBacklinkSummary = {
+      id: 'story-grown-2',
+      title: 'Another Story That Grew',
+      legacy_id: 'legacy-2',
+    };
+    renderBacklinks({ grownStories: [grownStory, secondGrownStory] });
+
+    expect(screen.getByTestId('grown-stories-backlink')).toBeInTheDocument();
+
+    const firstLink = screen.getByRole('link', { name: grownStory.title });
+    expect(firstLink).toHaveAttribute('href', '/legacy/legacy-1/story/story-grown');
+
+    const secondLink = screen.getByRole('link', { name: secondGrownStory.title });
+    expect(secondLink).toHaveAttribute('href', '/legacy/legacy-2/story/story-grown-2');
+  });
+
+  it('renders both sections at once when a story has both a source and grown stories', () => {
+    renderBacklinks({ sourceStory, grownStories: [grownStory] });
+
+    expect(screen.getByTestId('source-story-backlink')).toBeInTheDocument();
+    expect(screen.getByTestId('grown-stories-backlink')).toBeInTheDocument();
+  });
+
+  it('does not render a broken link when a backlink target has no legacy id', () => {
+    renderBacklinks({ sourceStory: { ...sourceStory, legacy_id: null } });
+
+    expect(screen.getByTestId('source-story-backlink')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText(sourceStory.title)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/story/components/StoryBacklinks.tsx
+++ b/apps/web/src/features/story/components/StoryBacklinks.tsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router-dom';
+import type { StoryBacklinkSummary } from '@/features/story/api/stories';
+
+interface StoryBacklinksProps {
+  /** The story this story grew out of (a response on it was converted here), if any. */
+  sourceStory: StoryBacklinkSummary | null;
+  /** Other stories that grew out of a response left on this story. */
+  grownStories: StoryBacklinkSummary[];
+}
+
+/** Builds the read-page path for a backlink target, or null if it can't be
+ * linked (a story summary without a legacy id — defensive, shouldn't happen
+ * in practice since story creation always requires a legacy). */
+function backlinkPath(story: StoryBacklinkSummary): string | null {
+  return story.legacy_id ? `/legacy/${story.legacy_id}/story/${story.id}` : null;
+}
+
+function BacklinkTitle({ story }: { story: StoryBacklinkSummary }) {
+  const path = backlinkPath(story);
+  if (!path) {
+    return <span className="font-medium text-neutral-600">{story.title}</span>;
+  }
+  return (
+    <Link
+      to={path}
+      className="font-medium text-neutral-600 underline underline-offset-2 hover:text-neutral-900"
+    >
+      {story.title}
+    </Link>
+  );
+}
+
+/**
+ * Quiet, reciprocal backlinks between a story and the story it grew out of
+ * (or the stories that grew out of it) — see openspec/changes/response-to-story.
+ * Renders nothing when there is neither a source story nor any grown stories.
+ */
+export default function StoryBacklinks({
+  sourceStory = null,
+  grownStories = [],
+}: StoryBacklinksProps) {
+  if (!sourceStory && grownStories.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8 space-y-2 text-sm text-neutral-500" data-testid="story-backlinks">
+      {sourceStory && (
+        <p data-testid="source-story-backlink">
+          Grew out of a memory on <BacklinkTitle story={sourceStory} />
+        </p>
+      )}
+      {grownStories.length > 0 && (
+        <div data-testid="grown-stories-backlink">
+          <p className="text-neutral-400">Stories grown from responses here</p>
+          <ul className="mt-1 space-y-0.5">
+            {grownStories.map((story) => (
+              <li key={story.id}>
+                <BacklinkTitle story={story} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/story/components/StoryEditPage.tsx
+++ b/apps/web/src/features/story/components/StoryEditPage.tsx
@@ -24,6 +24,14 @@ interface StoryEditPageProps {
 
 interface EditPageLocationState {
   seedQuote?: string;
+  /**
+   * Raw response body to seed the new story's content with, verbatim (no
+   * `> ` blockquote wrap, unlike `seedQuote`). Set when navigating here via
+   * a response's "make it a story" offer (see openspec/changes/response-to-story).
+   */
+  seedBody?: string;
+  /** The response this story is being converted from, when seeded via `seedBody`. */
+  sourceResponseId?: string;
 }
 
 type SaveState = 'idle' | 'saving' | 'saved' | 'error';
@@ -31,7 +39,14 @@ type SaveState = 'idle' | 'saving' | 'saved' | 'error';
 export default function StoryEditPage({ legacyId, storyId }: StoryEditPageProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const seedQuote = (location.state as EditPageLocationState | null)?.seedQuote;
+  const editLocationState = location.state as EditPageLocationState | null;
+  const seedQuote = editLocationState?.seedQuote;
+  const seedBody = editLocationState?.seedBody;
+  const sourceResponseId = editLocationState?.sourceResponseId;
+  // A response-conversion seed always wins over a story-prompt seed if both
+  // are somehow present (shouldn't normally happen — different entry points).
+  const seedContent = seedBody ?? (seedQuote ? `> ${seedQuote}\n\n` : '');
+  const isSeededFromResponse = !!(seedBody || sourceResponseId);
 
   const isNew = !storyId;
   const { data: existingStory, isLoading: storyLoading } = useStory(storyId);
@@ -39,7 +54,7 @@ export default function StoryEditPage({ legacyId, storyId }: StoryEditPageProps)
   const updateStory = useUpdateStory();
 
   const [title, setTitle] = useState('');
-  const [content, setContent] = useState(() => (seedQuote ? `> ${seedQuote}\n\n` : ''));
+  const [content, setContent] = useState(() => seedContent);
   const [visibility, setVisibility] = useState<Visibility>('private');
   const [saveState, setSaveState] = useState<SaveState>('idle');
 
@@ -95,12 +110,12 @@ export default function StoryEditPage({ legacyId, storyId }: StoryEditPageProps)
         setVisibility(existingStory.visibility);
       } else {
         setTitle('');
-        setContent(seedQuote ? `> ${seedQuote}\n\n` : '');
+        setContent(seedContent);
         setVisibility('private');
       }
       setSaveState('idle');
     }
-  }, [storyId, isNew, seedQuote, existingStory]);
+  }, [storyId, isNew, seedContent, existingStory]);
 
   useEffect(() => {
     return () => {
@@ -161,6 +176,7 @@ export default function StoryEditPage({ legacyId, storyId }: StoryEditPageProps)
         visibility: snapshot.visibility,
         status: 'draft',
         legacies: [{ legacy_id: legacyId, role: 'primary', position: 0 }],
+        source_response_id: sourceResponseId,
       });
       hasCreatedRef.current = true;
       effectiveIdRef.current = newStory.id;
@@ -181,7 +197,7 @@ export default function StoryEditPage({ legacyId, storyId }: StoryEditPageProps)
       creatingRef.current = false;
       setSaveState('error');
     }
-  }, [createStory, legacyId, navigate, runAutosave]);
+  }, [createStory, legacyId, navigate, runAutosave, sourceResponseId]);
 
   const handleChange = useCallback(
     (next: Partial<{ title: string; content: string; visibility: Visibility }>) => {
@@ -238,6 +254,11 @@ export default function StoryEditPage({ legacyId, storyId }: StoryEditPageProps)
         : saveState === 'error' ? "Couldn't save"
           : '';
 
+  // Story creation is lazy (first edit triggers runCreate), so a seeded
+  // draft that hasn't been touched yet isn't persisted anywhere. Surface
+  // that so the author knows to make a modification before navigating away.
+  const showNotSavedYetBadge = isSeededFromResponse && isNew && !hasCreatedRef.current;
+
   return (
     <div className="min-h-screen bg-theme-background transition-colors duration-300">
       <SEOHead title={title || 'Write a story'} description="Write a story" noIndex={true} />
@@ -249,6 +270,15 @@ export default function StoryEditPage({ legacyId, storyId }: StoryEditPageProps)
             Back
           </Button>
           <div className="flex items-center gap-3 shrink-0">
+            {showNotSavedYetBadge && (
+              <span
+                className="text-xs text-neutral-400 border border-neutral-200 rounded-full px-2 py-0.5"
+                title="Make an edit to save this as a new story."
+                data-testid="not-saved-yet-indicator"
+              >
+                Not saved yet
+              </span>
+            )}
             <span
               className={`text-xs ${saveState === 'error' ? 'text-destructive' : 'text-neutral-400'}`}
               role="status"

--- a/apps/web/src/features/story/components/StoryReadPage.test.tsx
+++ b/apps/web/src/features/story/components/StoryReadPage.test.tsx
@@ -130,6 +130,8 @@ const mockStoryData = {
   ],
   version_count: 3,
   has_draft: false,
+  source_story: null,
+  grown_from_responses: [],
   created_at: '2026-02-15T10:00:00Z',
   updated_at: '2026-02-16T10:00:00Z',
 };

--- a/apps/web/src/features/story/components/StoryReadPage.tsx
+++ b/apps/web/src/features/story/components/StoryReadPage.tsx
@@ -20,6 +20,7 @@ import { SEOHead } from '@/components/seo';
 import { getStoryDisplayTitle } from '@/features/story/utils/displayTitle';
 import ReactionsRow from '@/features/story-responses/components/ReactionsRow';
 import ResponsesSection from '@/features/story-responses/components/ResponsesSection';
+import StoryBacklinks from './StoryBacklinks';
 
 interface StoryReadPageProps {
   legacyId: string;
@@ -204,6 +205,13 @@ export default function StoryReadPage({ legacyId, storyId }: StoryReadPageProps)
         />
 
         {!isPreviewing && existingStory && (
+          <StoryBacklinks
+            sourceStory={existingStory.source_story}
+            grownStories={existingStory.grown_from_responses}
+          />
+        )}
+
+        {!isPreviewing && existingStory && (
           <div className="mt-8">
             <ReactionsRow
               storyId={existingStory.id}
@@ -221,8 +229,11 @@ export default function StoryReadPage({ legacyId, storyId }: StoryReadPageProps)
         {!isPreviewing && existingStory && canRespondOrReact && (
           <ResponsesSection
             storyId={existingStory.id}
+            legacyId={legacyId}
+            sourceStoryId={existingStory.id}
             currentUserId={user?.id}
             canModerate={canModerateResponses}
+            isStoryAuthor={isAuthor}
             responseCount={existingStory.response_count}
           />
         )}

--- a/openspec/changes/response-to-story/.openspec.yaml
+++ b/openspec/changes/response-to-story/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/response-to-story/design.md
+++ b/openspec/changes/response-to-story/design.md
@@ -1,0 +1,95 @@
+## Context
+
+This implements the stretch item deferred by the archived `story-responses` change (tasks 3.7 / 7.1–7.3). The base capability is live: responses render in a "Memories & responses" section on the story Read page, with author edit and author/admin delete. This adds: (a) an offer on a member's own long response, (b) conversion of that response into a standalone story, (c) a converted-note state on the original response, (d) a story-to-story backlink, and (e) a note-scoped hide power for the story author. All seven original questions plus five follow-ups are resolved (see `proposal.md`).
+
+Confirmed seams in the current code:
+
+- **Author gate exists.** `apps/web/src/features/story-responses/components/ResponseItem.tsx` computes `isOwnResponse`. It does **not** currently receive `legacyId` or the source story id.
+- **`legacyId` is upstream but not threaded down.** `StoryReadPage.tsx` has `legacyId` and `existingStory` and renders `<ResponsesSection storyId=… currentUserId=… canModerate=… />`.
+- **Edit-page seed seam.** `StoryEditPage.tsx` reads `location.state.seedQuote` and seeds `content` as a markdown blockquote; it has a `SaveState` machine (`idle | saving | saved | error`) and creates the story lazily via `runCreate` on the first `handleChange`. Precedent: `features/story-prompts/components/StoryPromptCard.tsx` navigates to `/legacy/:legacyId/story/new` with `state`.
+- **Create flow.** `useCreateStory` → `POST /api/stories/` accepts `{ legacies:[{ legacy_id }], title?, content, visibility?, status? }`; legacy linkage comes from the `:legacyId` path segment.
+- **Response model.** `services/core-api/app/models/story_response.py` has `body`, `created_at`, `edited_at`, `deleted_at` (soft delete). No story-to-story link exists anywhere in the DB today — "related stories" is a Neptune/graph concept (`apps/web/src/features/evolve-workspace/api/graphContext.ts`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reuse the existing seed-and-navigate seam and lazy-create behavior rather than inventing a new create path.
+- Make conversion recoverable: never destroy the member's original writing; a deleted story restores the response.
+- Keep the new moderation power tightly scoped to converted notes; leave general response moderation untouched.
+
+**Non-Goals:**
+- No AI/quality judgement — "long" is a sentence-count signal only.
+- No general story-author moderation of ordinary responses (deferred to a separate change).
+- No auto-publish; the seeded story enters the normal Edit flow at private.
+- No change to reactions, threading, or story/legacy access rules.
+
+## Decisions
+
+### D1. Offer placement and threshold
+
+Render the offer inside `ResponseItem`, gated by `isOwnResponse && isLongResponse(body) && !offerDismissed && !isConverted`. `ResponsesSection`/`StoryReadPage` thread `legacyId` and the source story id down. `isLongResponse` is a single util in `features/story-responses/utils/` with a hardcoded constant: **more than four sentences (5+)**, counted by a simple `.?!`-terminator split (R1) — accepted to miscount rare abbreviation/ellipsis/decimal cases for MVP. One testable place to tune later.
+
+### D2. Seeding and the non-atomic create (R1-adjacent)
+
+Extend `EditPageLocationState` with `seedBody?: string` (seeded **verbatim**, no `> ` wrap) plus `sourceResponseId?: string`; leave `seedQuote` untouched so the Story Prompt flow is unaffected. Keep the **lazy create** behavior; add a "not saved yet" affordance driven off `isNew && !hasCreated` (e.g. a badge/tooltip near the save-state indicator) telling the author an edit will save the draft (R2 of the original set / owner's caveat handling). We deliberately do **not** force eager-create on mount — that would risk creating empty stories for abandoned Story-Prompt seeds; the note replacement is simply deferred until the story actually exists.
+
+### D3. Data model (Option C + backlink + dismissal + hide)
+
+`story_responses` gains:
+| column | type | notes |
+|---|---|---|
+| `converted_story_id` | UUID fk → `stories.id`, **`ondelete=SET NULL`**, nullable | non-null ⇒ this row renders as a note; SET NULL means deleting the story auto-restores the response (R3) |
+| `hidden_at` | timestamptz, nullable | note hidden by the story author; visible only to the note's author (R2) |
+| `hidden_by_id` | UUID fk → `users.id`, nullable | who hid it (audit) |
+| `offer_dismissed_at` | timestamptz, nullable | server-side, per-response dismissal (R4) |
+
+`stories` gains:
+| column | type | notes |
+|---|---|---|
+| `source_story_id` | UUID fk → `stories.id`, **`ondelete=SET NULL`**, nullable | backlink to the story the source response was on (R5) |
+
+The original `body` is **retained** on conversion (not cleared) so restore is trivial — the note is a *render-time* decision on `converted_story_id`, not a destructive edit.
+
+### D4. Create-from-response wiring
+
+Extend the create endpoint/schema to accept an optional `source_response_id`. When present, in **one transaction**: create the story, set `story.source_story_id = source_response.story_id`, and set `source_response.converted_story_id = new_story.id`. The frontend carries `sourceResponseId` through nav state into the create mutation. Because create is lazy, this fires on the first edit's `runCreate` — matching the owner's "make a modification to save" model. Serializers expose the note link (source response → converted story summary) and the backlink (story → source story summary).
+
+*Alternative considered (rejected): a separate POST /responses/{id}/convert endpoint that creates the story eagerly.* Rejected because it duplicates create logic and forces eager creation, producing empty stories if the author abandons the draft.
+
+### D5. Note moderation — notes-only (R2)
+
+Add a story-author hide action (e.g. `POST /api/stories/{story_id}/responses/{response_id}/hide`) that sets `hidden_at` + `hidden_by_id`, authorized to the **story author** only and rejected unless the target is a converted note (`converted_story_id` is non-null). Response **list filtering** excludes rows with `hidden_at` set unless the viewer is the note's author (`user_id`). The existing "Response removal rights" (author + legacy creator/admin, hard soft-delete for everyone) is **unchanged** and continues to apply to notes as to responses. Deleting a note reuses the existing response delete.
+
+*Alternative considered (rejected): apply the hidden-from-others outcome to all responses and add the story author as a general remover.* Rejected for scope — it modifies the existing removal-rights requirement and adds a visibility tier for every response; split to its own proposal.
+
+### D6. Dismissal (R4)
+
+A small PATCH (e.g. `PATCH /api/stories/{story_id}/responses/{response_id}` or a dedicated dismiss route, matching existing response-route conventions) sets `offer_dismissed_at`, author-only. The serializer exposes it; the frontend suppresses the offer when set. Server-side (not localStorage) so dismissal is cross-device.
+
+## Risks / Trade-offs
+
+- **[Sentence counting is heuristic]** (`.?!` split miscounts abbreviations/ellipses/decimals) → accepted for MVP; isolated in one util with boundary tests; tune later without touching callers.
+- **[Non-atomic conversion]** (author takes the offer, never edits ⇒ story never created ⇒ response stays a normal response) → correct by design; the note replacement only runs in the create success path, and the "not saved yet" indicator nudges the author.
+- **[Duplicate-then-restore churn]** (convert, then delete the story ⇒ response returns) → intended; `SET NULL` + retained `body` make it lossless.
+- **[Hidden note + later story delete]** (a hidden note whose story is deleted becomes a restored-but-still-hidden response) → minor edge; default is to leave `hidden_at` as-is on restore (a story author who hid it keeps it hidden); revisit only if it confuses users.
+- **[Seed text formatting]** (markdown-like characters in a response render as formatting) → same as any pasted text today; covered by a plain-text seed test.
+- **[PR size]** (backend model + endpoints + several UI surfaces) → split into ~2–3 PRs per the task groups; each stays under the 400 LOC target.
+
+## Migration Plan
+
+Two additive Alembic migrations, no backfill:
+1. `story_responses`: add `converted_story_id` (FK `ondelete=SET NULL`), `hidden_at`, `hidden_by_id` (FK), `offer_dismissed_at` — all nullable.
+2. `stories`: add `source_story_id` (FK `ondelete=SET NULL`), nullable.
+
+Both are backward-compatible and deployable ahead of the frontend that reads them. Rollback is `alembic downgrade -1` per migration; nothing existing is altered. The `SET NULL` FKs encode the R3 restore/backlink-drop behavior at the database level.
+
+## Observability
+
+Following the existing `story_response.*` span/log naming from the archived change (component `story-responses`):
+- **Spans:** `story_response.convert` (create-from-response wiring), `story_response.hide`, `story_response.dismiss_offer`.
+- **Logs:** `story_response.converted` (fields `story_id` = new story, `source_response_id`, `source_story_id`, `legacy_id`, `user_id`), `story_response.hidden` (`response_id`, `story_id`, `hidden_by_id`), `story_response.offer_dismissed` (`response_id`, `user_id`) — structured JSON alongside the standard `service`/`component`/`version`/`request_id` fields.
+- **Metrics:** counter `story_responses_converted_total` (labels `service`, `component`, `version`). Optional frontend UI event `response_to_story.offer_taken` if the app has a client analytics hook.
+
+## Open Questions
+
+None remain blocking apply. One item is explicitly **deferred to a separate change**: general story-author moderation of any response (the hidden-from-others outcome applied beyond converted notes).

--- a/openspec/changes/response-to-story/proposal.md
+++ b/openspec/changes/response-to-story/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+A member sometimes answers a story with a response so long and self-contained that it is really a story of its own — a full memory, not a comment. Today that writing is trapped in the flat responses list: it cannot be titled, given its own reading page, surfaced on the legacy, or responded to in turn. This closes the loop the archived `story-responses` change deliberately deferred (stretch tasks 3.7 / 7.1–7.3), turning a rich response into a first-class story with one gentle offer.
+
+## What Changes
+
+- On a member's **own** response of **more than four sentences**, the responses section shows a gentle, inline offer (e.g. "This sounds like its own story"). The offer never appears on other members' responses or on short responses. It is **dismissible once per response**.
+- Taking the offer opens the story **Edit page pre-seeded with the response's text (raw body, verbatim)**, associated with the **same legacy** the story belongs to, and defaulting to **private** — reusing the existing Edit-page seed-and-navigate seam (`location.state`, as `StoryPromptCard` already does).
+- Because story creation is **not atomic** (the Edit page only persists on the first edit), the seeded Edit page shows a **"not saved yet" indicator** with guidance (e.g. hover tooltip: make an edit to save) so the author knows autosave needs a modification to fire.
+- Once the new story is actually created, the **original response is replaced in place with a short note + link** to the new story ("Turned this into a story →"). The note is **not editable**; its author may delete it.
+- The new story records a **link back to the source story** (a nullable `source_story_id` FK, in addition to the legacy) so readers can explore related stories from either side.
+- The **story author** (of the story the response was written against) can hide a **converted note** such that it stays visible to its own author but is hidden from everyone else — a new "hidden" moderation state, **scoped to notes only** in this change (broader response moderation is split to a separate proposal).
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `story-responses`: adds three requirements — (1) a member can turn their own long (>4-sentence) response into a standalone story, seeded with the response text, defaulting to private, linked to the same legacy and back to the source story, with a dismissible offer; (2) a converted response becomes a non-editable, deletable note linking to the new story, and reverts to the original response if that story is deleted; (3) the story author can hide a converted note from others while keeping it visible to its author. The existing "Response removal rights" requirement is **not changed** (R2: notes-only scope); broader story-author response moderation is deferred to its own proposal.
+
+## Impact
+
+- **Frontend** (`apps/web`):
+  - `features/story-responses/`: a ">4 sentences" check + gentle, dismissible inline offer on the author's own response (`ResponseItem.tsx` already computes `isOwnResponse`); thread `legacyId` (and source story id) down through `ResponsesSection` from `StoryReadPage`; render the converted **note** state (link, no edit, delete only) and the "hidden" state.
+  - `features/story/components/StoryEditPage.tsx`: extend `EditPageLocationState` to seed a raw body (`seedBody`) and carry `sourceResponseId`/`sourceStoryId`; add the "not saved yet" indicator for seeded-but-uncreated drafts; default seeded story to private.
+  - Story read page: render the "grew out of a memory on …" backlink to the source story.
+- **Backend** (`services/core-api`) — now required (Option C + backlink + moderation):
+  - `story_responses`: add `converted_story_id` (nullable FK → stories, `ondelete=SET NULL` so deleting the story auto-restores the response — R3); `hidden_at` + `hidden_by_id` (note-scoped "hidden from others" state, distinct from `deleted_at` — R2); `offer_dismissed_at` (server-side per-response dismissal — R4).
+  - `stories`: add `source_story_id` (nullable FK → stories, `ondelete=SET NULL`) for the backlink (R5).
+  - New/updated endpoints: create-from-response wiring (create endpoint accepts optional `source_response_id`; in one transaction sets the new story's `source_story_id` and the source response's `converted_story_id`); dismiss-offer; story-author hide-note; note delete reuses the existing response delete. Response serializer exposes note/hidden/dismissal fields + linked-story summary; story serializer exposes the source-story backlink. List filtering hides hidden notes from everyone but the note's author.
+  - Two additive Alembic migrations (response columns; story column).
+- **Routing/API**: reuses the create route (`legacy/:legacyId/story/new`) and create mutation, plus the new response-conversion/moderation endpoints above.
+- Requirement source: archived `story-responses` tasks 3.7 / 7.1–7.3 (`openspec/changes/archive/2026-07-09-story-responses/tasks.md`).
+- **Size note:** with Option C + backlink + moderation this is no longer a single <400 LOC PR; expect a split into ~2–3 PRs (backend model/endpoints; offer + seed + note UI; backlink + moderation UI).
+
+## Non-goals
+
+- No AI/heuristic detection of "story-worthiness" beyond the sentence-count signal — "long" is a length signal, not a quality judgement.
+- No threaded replies, rich text, or any change to reactions — unchanged from the `story-responses` non-goals.
+- No change to story or legacy **access/visibility** rules; the offer is a UI affordance layered on read access.
+- No offer on **other members'** responses, and no admin/moderator "promote this response" action — a member converts only their own writing.
+- No automatic publish — the seeded story lands in the normal Edit flow at private; the author decides title, visibility, and whether to publish.
+- No migration/backfill of existing responses into stories.
+
+## Resolved Decisions
+
+The seven open questions were resolved by the owner (2026-07-10):
+
+1. **"Long" threshold** → a response of **more than four sentences**. Hardcoded constant for now (no config).
+2. **Original response after conversion** → **Option C: replaced in place with a short note + link** to the new story. To handle the non-atomic create, the seeded Edit page surfaces a "not saved yet" indicator instructing the author that a modification triggers autosave; the note replacement happens only after the story is actually created.
+3. **Dismissible?** → **Yes, shown once and dismissible, dismissal is per response.**
+4. **Interaction with edit/delete after conversion** → the converted note is **not editable**; the note's author (the response author) can **delete** it. Additionally, the **story author** can remove any response/note, with the outcome that it stays **visible to its own author but hidden from everyone else** (new "hidden" state — see R2).
+5. **Seed raw or blockquote?** → **Raw body, verbatim** (no `> ` wrap).
+6. **Backlink to source?** → **Yes** — in addition to the legacy, the new story links to the **source story** so people can explore related stories.
+7. **Default visibility/status** → **private**; the author adjusts permissions afterward.
+
+## Follow-up Decisions (from resolving the answers above)
+
+Settled by the owner (2026-07-10); no open questions remain blocking apply:
+
+- **R1 — Sentence-count rule** → the offer appears at **5+ sentences** (strictly more than four), counted with a simple `.?!`-based splitter for MVP (occasional miscounts on abbreviations/ellipses accepted).
+- **R2 — Moderation scope** → **notes only.** The story-author "hide from others, keep visible to its author" outcome applies only to converted notes. The existing `story-responses` "Response removal rights" requirement is unchanged; broader story-author response moderation is **split to a separate future proposal**.
+- **R3 — Note lifecycle** → **restore the original response** when the converted story is deleted (implemented via `converted_story_id` `ondelete=SET NULL`; the original body is retained, so the response becomes editable again). If the **source** story is deleted, the new story's backlink is simply dropped (`source_story_id` `ondelete=SET NULL`).
+- **R4 — Dismissal persistence** → **server-side** `offer_dismissed_at` on the response (cross-device).
+- **R5 — Backlink mechanism** → **DB FK** `source_story_id` on `stories`. Rendered on the new story's read page ("grew out of a memory on …") and reciprocally on the source story (stories that grew from its responses).
+
+**Deferred to a separate change:** general story-author moderation of any response (the hidden-from-others outcome applied beyond converted notes).

--- a/openspec/changes/response-to-story/specs/story-responses/spec.md
+++ b/openspec/changes/response-to-story/specs/story-responses/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Members can turn their own long response into a standalone story
+
+The author of a response of **more than four sentences** SHALL be offered a gentle, inline way to turn that response into its own standalone story. Taking the offer SHALL open the story Edit page pre-seeded with the response's text **verbatim** (as raw body, not a quotation), associated with the **same legacy** the responded-to story belongs to, defaulting to **private** visibility. The offer SHALL be shown only to the response's own author, SHALL NOT appear on another member's response or on a response of four or fewer sentences, and SHALL be **dismissible once per response** (persisted so it does not reappear for that response). The offer SHALL NOT, by itself, change any story or legacy access rule, publish anything, or alter the response's content.
+
+#### Scenario: Author of a long response is offered to make it a story
+- **WHEN** a member views their own response of more than four sentences
+- **THEN** a gentle inline offer (e.g. "This sounds like its own story") is shown on that response
+
+#### Scenario: Short response shows no offer
+- **WHEN** a member views their own response of four or fewer sentences
+- **THEN** no "make this a story" offer is shown on that response
+
+#### Scenario: Offer is author-only
+- **WHEN** a member views another member's response, however long
+- **THEN** no "make this a story" offer is shown to them for that response
+
+#### Scenario: Taking the offer seeds a private new story in the same legacy
+- **WHEN** the author takes the offer on their long response
+- **THEN** the story Edit page opens pre-filled with the response's text verbatim, associated with the same legacy as the responded-to story, and defaulted to private, ready for the author to title, edit, and choose whether to publish
+
+#### Scenario: Dismissing the offer hides it for that response
+- **WHEN** the author dismisses the offer on a response
+- **THEN** the offer is not shown again for that response, including on a later visit or another device
+
+#### Scenario: Seeded draft indicates it is not yet saved
+- **WHEN** the author is on the seeded Edit page but has not yet made an edit
+- **THEN** an indicator communicates the story is not saved yet and that making a modification will save it (the draft is not persisted until the first edit)
+
+### Requirement: A converted response becomes a non-editable note linking to the new story
+
+Once the seeded story is created, the source response SHALL be presented as a **note** that links to the new story (e.g. "Turned this into a story →") instead of its original body, and the note SHALL NOT be editable. The new story SHALL record a link back to the **source story** so readers can navigate between the two. The note's author SHALL be able to delete the note. If the converted story is later deleted, the original response SHALL be restored (its original body, editable again).
+
+#### Scenario: Source response renders as a note after the story is created
+- **WHEN** the seeded story has been created from a response
+- **THEN** that response is shown as a note linking to the new story, with no in-place edit affordance
+
+#### Scenario: New story links back to the source story
+- **WHEN** a reader views a story that was created from a response
+- **THEN** the story shows a link back to the source story it grew out of, and the source story reciprocally surfaces the stories grown from its responses
+
+#### Scenario: Note author deletes the note
+- **WHEN** the author of a note deletes it
+- **THEN** the note no longer appears in the response list
+
+#### Scenario: Deleting the converted story restores the original response
+- **WHEN** the story created from a response is deleted
+- **THEN** the note reverts to the original response with its original body, editable by its author again
+
+### Requirement: The story author can hide a converted note from others
+
+The author of the story a response was written against SHALL be able to hide a **converted note** so that it remains visible to the note's own author but is hidden from every other viewer. This applies only to converted notes; it does not change the existing response removal rights (author or legacy creator/admin) for ordinary responses.
+
+#### Scenario: Story author hides a note
+- **WHEN** the author of the story hides a converted note on that story
+- **THEN** the note is no longer shown to other viewers of the story
+
+#### Scenario: Hidden note stays visible to its own author
+- **WHEN** the author of a note that the story author has hidden views the story
+- **THEN** they still see their own note

--- a/openspec/changes/response-to-story/tasks.md
+++ b/openspec/changes/response-to-story/tasks.md
@@ -1,0 +1,54 @@
+Suggested PR split (each < 400 LOC): **PR1** = §1–4 (backend), **PR2** = §5 + §8 (offer/seed/convert UI), **PR3** = §6–7 + §8 (note/backlink/hide UI). Reference change id `response-to-story` in each PR.
+
+## 1. Backend: data model + migrations
+
+- [x] 1.1 Add columns to `StoryResponse` (`app/models/story_response.py`): `converted_story_id` (UUID FK → `stories.id`, `ondelete="SET NULL"`, nullable, indexed), `hidden_at` (timestamptz nullable), `hidden_by_id` (UUID FK → `users.id`, nullable), `offer_dismissed_at` (timestamptz nullable). Keep `body` on conversion (needed for restore).
+- [x] 1.2 Add `source_story_id` (UUID FK → `stories.id`, `ondelete="SET NULL"`, nullable, indexed) to `Story` (`app/models/story.py`).
+- [x] 1.3 Alembic migration #1: the four `story_responses` columns. Additive/nullable; rollback `downgrade -1`.
+- [x] 1.4 Alembic migration #2: the `stories.source_story_id` column. Additive/nullable.
+
+## 2. Backend: create-from-response wiring
+
+- [x] 2.1 Extend the create story schema/endpoint to accept optional `source_response_id` (`app/schemas/story.py`, `app/routes/story*.py`).
+- [x] 2.2 In the create service, when `source_response_id` is present, in ONE transaction: create the story, set `story.source_story_id = source_response.story_id`, set `source_response.converted_story_id = new_story.id`. Authorize that the actor is the source response's author.
+- [x] 2.3 Update the story serializer to expose a `source_story` summary (id/title/link) for the backlink, and a reciprocal "stories grown from responses" surface on the source story.
+- [x] 2.4 Update the response serializer to expose `converted_story_id` + a converted-story summary (id/title/link), `offer_dismissed_at`, and a per-viewer `hidden` flag.
+- [x] 2.5 Emit span `story_response.convert` and log `story_response.converted` (fields per design's Observability) + `story_responses_converted_total` metric.
+
+## 3. Backend: dismissal, note hide, list filtering, restore
+
+- [x] 3.1 Add a dismiss action (PATCH on the response, or dedicated route) that sets `offer_dismissed_at`; author-only.
+- [x] 3.2 Add a story-author hide action (`POST /api/stories/{story_id}/responses/{response_id}/hide`) setting `hidden_at` + `hidden_by_id`; authorized to the story's author only; reject unless the target is a converted note (`converted_story_id` non-null). Emit `story_response.hide` span / `story_response.hidden` log.
+- [x] 3.3 Update response list filtering: exclude rows with `hidden_at` set unless the viewer is the note's author (`user_id`).
+- [x] 3.4 Confirm restore works via FK: deleting the converted story sets `converted_story_id` NULL (response reverts to editable); deleting the source story sets `source_story_id` NULL (backlink drops). Add a service/integration test asserting both.
+
+## 4. Backend: tests + validation
+
+- [x] 4.1 Tests: create-from-response sets both FKs; note render fields present; author-only convert; dismissal author-only; hide is story-author-only and note-only; hidden note filtered for others but visible to its author; restore-on-story-delete; backlink-drop-on-source-delete.
+- [x] 4.2 Run `just validate-backend` and `uv run pytest` (services/core-api) — must pass before opening the PR.
+
+## 5. Frontend: offer + long check + seed seam
+
+- [x] 5.1 Add `isLongResponse(body)` util in `features/story-responses/utils/` — hardcoded constant: more than four sentences (5+), simple `.?!` splitter; boundary unit tests.
+- [x] 5.2 Thread `legacyId` and the source story id from `StoryReadPage` → `ResponsesSection` → `ResponseItem` (add to each props interface).
+- [x] 5.3 In `ResponseItem`, render the gentle, dismissible inline offer only when `isOwnResponse && isLongResponse(body) && !offer_dismissed_at && converted_story_id == null` and not on `temp-` rows. Grief-sensitive copy (e.g. "This sounds like its own story"); quiet, not a prominent CTA. Wire the dismiss action to the backend (§3.1) and invalidate the responses query.
+- [x] 5.4 On take: `navigate(\`/legacy/${legacyId}/story/new\`, { state: { seedBody: response.body, sourceResponseId: response.id } })` (mirror `StoryPromptCard`).
+- [x] 5.5 Extend `EditPageLocationState` in `StoryEditPage.tsx` with `seedBody?` (verbatim, no `> ` wrap) and `sourceResponseId?`; seed `content` from `seedBody` in both the initial `useState` and the `storyId`-change effect; default seeded story `visibility` to private; pass `source_response_id` into the create mutation. Leave `seedQuote` behavior unchanged.
+- [x] 5.6 Add the "not saved yet" indicator on the seeded Edit page (driven off `isNew && !hasCreated`) with guidance that an edit will save the draft.
+
+## 6. Frontend: note render + backlink + hide
+
+- [x] 6.1 Render the converted-note state in `ResponseItem` when `converted_story_id != null`: show "Turned this into a story →" linking to the new story; hide the edit affordance; keep delete for the note's author.
+- [x] 6.2 Render the backlink on the story read page ("grew out of a memory on …" → source story) and the reciprocal "stories grown from responses" surface on the source story.
+- [x] 6.3 Add the story-author "hide note" affordance (visible to the story's author on a converted note) wired to §3.2; invalidate the responses query on success. Do not render hidden notes for non-authors (server already filters; the UI must not assume presence).
+
+## 7. Frontend: tests
+
+- [x] 7.1 Component tests (`ResponseItem`): offer shown for own long, undismissed, unconverted response; absent for own short, others', dismissed, converted, and `temp-` rows; take-action navigates with `seedBody` + `sourceResponseId` and correct `legacyId`; note state renders link + no edit + delete-for-author; hide affordance visible only to the story author.
+- [x] 7.2 Test that a plain-text response seeds as plain body (no unintended markdown formatting).
+- [x] 7.3 Test the backlink render on both the new story and the source story.
+
+## 8. Validation & end-to-end verification
+
+- [x] 8.1 Run `npm run lint` and `npm run test` (apps/web) — must pass before opening each frontend PR.
+- [x] 8.2 Drive the flow in the running compose stack (per AGENTS.md "verify, don't just validate"): post a >4-sentence response, take the offer, confirm the seeded Edit page (raw body, same legacy, private, "not saved" indicator), make an edit to save, then confirm the original response became a note linking to the new story and the new story links back to the source; delete the new story and confirm the response is restored; as the story author, hide a note and confirm it disappears for another member but stays for its author; dismiss an offer and confirm it stays dismissed.

--- a/services/core-api/alembic/versions/2107c02a3f1b_add_story_source_story_id_backlink_.py
+++ b/services/core-api/alembic/versions/2107c02a3f1b_add_story_source_story_id_backlink_.py
@@ -1,0 +1,48 @@
+"""add story source_story_id backlink column
+
+Revision ID: 2107c02a3f1b
+Revises: b0a29ab45f6d
+Create Date: 2026-07-10 00:38:24.907324
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2107c02a3f1b"
+down_revision = "b0a29ab45f6d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "stories",
+        sa.Column("source_story_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_stories_source_story_id_stories",
+        "stories",
+        "stories",
+        ["source_story_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        op.f("ix_stories_source_story_id"),
+        "stories",
+        ["source_story_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_stories_source_story_id"), table_name="stories")
+    op.drop_constraint(
+        "fk_stories_source_story_id_stories",
+        "stories",
+        type_="foreignkey",
+    )
+    op.drop_column("stories", "source_story_id")

--- a/services/core-api/alembic/versions/b0a29ab45f6d_add_response_conversion_and_moderation_.py
+++ b/services/core-api/alembic/versions/b0a29ab45f6d_add_response_conversion_and_moderation_.py
@@ -1,0 +1,80 @@
+"""add response conversion and moderation columns
+
+Revision ID: b0a29ab45f6d
+Revises: 419b383433da
+Create Date: 2026-07-10 00:38:21.213903
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b0a29ab45f6d"
+down_revision = "419b383433da"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "story_responses",
+        sa.Column("converted_story_id", sa.UUID(), nullable=True),
+    )
+    op.add_column(
+        "story_responses",
+        sa.Column("hidden_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "story_responses",
+        sa.Column("hidden_by_id", sa.UUID(), nullable=True),
+    )
+    op.add_column(
+        "story_responses",
+        sa.Column("offer_dismissed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_foreign_key(
+        "fk_story_responses_converted_story_id_stories",
+        "story_responses",
+        "stories",
+        ["converted_story_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_story_responses_hidden_by_id_users",
+        "story_responses",
+        "users",
+        ["hidden_by_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.create_index(
+        op.f("ix_story_responses_converted_story_id"),
+        "story_responses",
+        ["converted_story_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_story_responses_converted_story_id"), table_name="story_responses"
+    )
+    op.drop_constraint(
+        "fk_story_responses_hidden_by_id_users",
+        "story_responses",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_story_responses_converted_story_id_stories",
+        "story_responses",
+        type_="foreignkey",
+    )
+    op.drop_column("story_responses", "offer_dismissed_at")
+    op.drop_column("story_responses", "hidden_by_id")
+    op.drop_column("story_responses", "hidden_at")
+    op.drop_column("story_responses", "converted_story_id")

--- a/services/core-api/app/models/story.py
+++ b/services/core-api/app/models/story.py
@@ -115,8 +115,18 @@ class Story(Base):
         default=None,
     )
 
+    source_story_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("stories.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
     # Relationships
     author: Mapped["User"] = relationship("User", foreign_keys=[author_id])
+    source_story: Mapped["Story | None"] = relationship(
+        "Story", remote_side=[id], foreign_keys=[source_story_id]
+    )
     legacy_associations: Mapped[list["StoryLegacy"]] = relationship(
         "StoryLegacy",
         cascade="all, delete-orphan",

--- a/services/core-api/app/models/story_response.py
+++ b/services/core-api/app/models/story_response.py
@@ -63,9 +63,36 @@ class StoryResponse(Base):
         nullable=True,
     )
 
+    converted_story_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("stories.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    hidden_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    hidden_by_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    offer_dismissed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
     # Relationships
     story: Mapped["Story"] = relationship("Story", foreign_keys=[story_id])
     user: Mapped["User"] = relationship("User", foreign_keys=[user_id])
+    converted_story: Mapped["Story | None"] = relationship(
+        "Story", foreign_keys=[converted_story_id]
+    )
+    hidden_by: Mapped["User | None"] = relationship("User", foreign_keys=[hidden_by_id])
 
     def __repr__(self) -> str:
         return (

--- a/services/core-api/app/routes/story_response.py
+++ b/services/core-api/app/routes/story_response.py
@@ -124,3 +124,48 @@ async def delete_response(
         response_id=response_id,
         user_id=session.user_id,
     )
+
+
+@router.post(
+    "/{response_id}/dismiss-offer",
+    response_model=StoryResponseItem,
+    summary="Dismiss the 'make this a story' offer",
+    description="Persist that the response's author dismissed the conversion "
+    "offer for this response. Author-only.",
+)
+async def dismiss_offer(
+    story_id: UUID,
+    response_id: UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> StoryResponseItem:
+    session = require_auth(request)
+    return await story_response_service.dismiss_offer(
+        db=db,
+        story_id=story_id,
+        response_id=response_id,
+        user_id=session.user_id,
+    )
+
+
+@router.post(
+    "/{response_id}/hide",
+    response_model=StoryResponseItem,
+    summary="Hide a converted note from other viewers",
+    description="Hide a converted note so it stays visible to its own author "
+    "but is hidden from everyone else. Story-author-only; the target must be "
+    "a converted note.",
+)
+async def hide_response(
+    story_id: UUID,
+    response_id: UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> StoryResponseItem:
+    session = require_auth(request)
+    return await story_response_service.hide_response(
+        db=db,
+        story_id=story_id,
+        response_id=response_id,
+        user_id=session.user_id,
+    )

--- a/services/core-api/app/schemas/story.py
+++ b/services/core-api/app/schemas/story.py
@@ -35,6 +35,12 @@ class StoryCreate(BaseModel):
         min_length=1,
         description="Legacies this story is about (at least one required)",
     )
+    source_response_id: UUID | None = Field(
+        default=None,
+        description="The response this story is converted from, if any. Must "
+        "be authored by the requesting user; the source response is replaced "
+        "in place with a note linking back to the new story.",
+    )
 
     @field_validator("legacies")
     @classmethod
@@ -159,6 +165,16 @@ class StoryScopedResponse(BaseModel):
     counts: StoryScopeCounts
 
 
+class StoryBacklinkSummary(BaseModel):
+    """Summary of a related story used for source/grown-from backlinks."""
+
+    id: UUID
+    title: str
+    legacy_id: UUID | None = None
+
+    model_config = {"from_attributes": True}
+
+
 class StoryDetail(BaseModel):
     """Schema for full story details."""
 
@@ -176,6 +192,17 @@ class StoryDetail(BaseModel):
     version_count: int | None = None
     has_draft: bool | None = None
     source_conversation_id: UUID | None = None
+    source_story: StoryBacklinkSummary | None = Field(
+        default=None,
+        description="This story's backlink to the story it grew out of, when "
+        "it was created from a response on another story",
+    )
+    grown_from_responses: list[StoryBacklinkSummary] = Field(
+        default_factory=list,
+        description="Other stories whose source_story_id points at this "
+        "story (i.e. stories that grew out of a response left here), "
+        "filtered to those the requesting viewer can read",
+    )
     favorite_count: int = Field(
         default=0, description="Number of times this story has been favorited"
     )

--- a/services/core-api/app/schemas/story_response.py
+++ b/services/core-api/app/schemas/story_response.py
@@ -50,6 +50,16 @@ class StoryResponseUpdate(StoryResponseBody):
     """Schema for editing an existing story response."""
 
 
+class ConvertedStorySummary(BaseModel):
+    """Summary of the story a response was converted into."""
+
+    id: UUID
+    title: str
+    legacy_id: UUID | None = None
+
+    model_config = {"from_attributes": True}
+
+
 class StoryResponseItem(BaseModel):
     """A single response returned by the API."""
 
@@ -64,6 +74,26 @@ class StoryResponseItem(BaseModel):
     edited_at: datetime | None = Field(
         default=None,
         description="Non-null when the response has been edited since creation",
+    )
+    converted_story_id: UUID | None = Field(
+        default=None,
+        description="Non-null when this response was converted into a standalone "
+        "story; the response renders as a non-editable note linking to it",
+    )
+    converted_story: ConvertedStorySummary | None = Field(
+        default=None,
+        description="Summary of the converted story, when converted_story_id is set",
+    )
+    offer_dismissed_at: datetime | None = Field(
+        default=None,
+        description="Non-null once the response's author has dismissed the "
+        "'make this a story' offer for this response",
+    )
+    hidden: bool = Field(
+        default=False,
+        description="True when the story author has hidden this converted note "
+        "from other viewers. List filtering means only the note's own author "
+        "will ever actually receive hidden=True.",
     )
 
     model_config = {"from_attributes": True}

--- a/services/core-api/app/services/story.py
+++ b/services/core-api/app/services/story.py
@@ -17,9 +17,11 @@ from ..models.associations import StoryLegacy
 from ..models.legacy import Legacy, LegacyMember
 from ..models.story import Story
 from ..models.story_reaction import StoryReaction as StoryReactionModel
+from ..models.story_response import StoryResponse as StoryResponseModel
 from ..models.story_version import StoryVersion
 from ..schemas.associations import LegacyAssociationResponse
 from ..schemas.story import (
+    StoryBacklinkSummary,
     StoryCreate,
     StoryDetail,
     StoryResponse,
@@ -27,6 +29,7 @@ from ..schemas.story import (
     StoryUpdate,
 )
 from ..schemas.story_reaction import ReactionType
+from . import story_response as story_response_service
 from .change_summary import generate_change_summary
 from .story_access import (
     ACTIVE_ROLES,
@@ -202,6 +205,80 @@ async def _get_legacy_names(
     return {row[0]: row[1] for row in result.all()}
 
 
+def _primary_legacy_id(story: Story) -> UUID | None:
+    """Return a story's primary legacy id, falling back to the first one."""
+    if not story.legacy_associations:
+        return None
+    primary = next(
+        (assoc for assoc in story.legacy_associations if assoc.role == "primary"),
+        story.legacy_associations[0],
+    )
+    return primary.legacy_id
+
+
+async def _load_backlink_summary(
+    db: AsyncSession, story_id: UUID | None
+) -> StoryBacklinkSummary | None:
+    """Resolve a story's title + primary legacy for a backlink summary.
+
+    Returns None when `story_id` is None, or when the story no longer exists
+    (e.g. the source story was deleted, which auto-nulls the backlink FK —
+    this defensive lookup-miss path should not normally be hit).
+    """
+    if story_id is None:
+        return None
+    result = await db.execute(
+        select(Story)
+        .options(selectinload(Story.legacy_associations))
+        .where(Story.id == story_id)
+    )
+    story = result.scalar_one_or_none()
+    if story is None:
+        return None
+    return StoryBacklinkSummary(
+        id=story.id,
+        title=story.title,
+        legacy_id=_primary_legacy_id(story),
+    )
+
+
+async def _load_grown_from_responses(
+    db: AsyncSession, story_id: UUID, user_id: UUID
+) -> list[StoryBacklinkSummary]:
+    """Stories whose `source_story_id` points at `story_id`, viewer-filtered.
+
+    Reciprocal side of the source-story backlink: "stories grown from
+    responses on this story." Filtered per-candidate with `can_read_story`
+    (plus the same author-only draft rule `get_story_detail` applies to the
+    story itself) so private/draft stories grown from someone else's
+    response are never leaked. The candidate set is expected to be small, so
+    a per-row authorization loop is used rather than a bulk query.
+    """
+    result = await db.execute(
+        select(Story)
+        .options(selectinload(Story.legacy_associations))
+        .where(Story.source_story_id == story_id)
+        .order_by(Story.created_at.asc())
+    )
+    candidates = result.scalars().unique().all()
+
+    summaries: list[StoryBacklinkSummary] = []
+    for candidate in candidates:
+        if candidate.status == "draft" and candidate.author_id != user_id:
+            continue
+        allowed, _reason = await can_read_story(db, candidate, user_id)
+        if not allowed:
+            continue
+        summaries.append(
+            StoryBacklinkSummary(
+                id=candidate.id,
+                title=candidate.title,
+                legacy_id=_primary_legacy_id(candidate),
+            )
+        )
+    return summaries
+
+
 async def _ensure_contributor_access(
     db: AsyncSession,
     user_id: UUID,
@@ -268,6 +345,17 @@ async def create_story(
 
     await _ensure_contributor_access(db, user_id, legacy_ids)
 
+    # Create-from-response wiring: only the response's own author may convert
+    # it. Loaded up front so an unauthorized/missing response 403s/404s
+    # before any story row is created.
+    source_response: StoryResponseModel | None = None
+    if data.source_response_id is not None:
+        source_response = await story_response_service.load_response_for_conversion(
+            db=db,
+            response_id=data.source_response_id,
+            user_id=user_id,
+        )
+
     provided_title = (data.title or "").strip()
     if provided_title:
         title = provided_title
@@ -284,8 +372,14 @@ async def create_story(
         visibility=data.visibility,
         status=data.status,
     )
+    if source_response is not None:
+        story.source_story_id = source_response.story_id
     db.add(story)
     await db.flush()  # Get story.id without committing
+
+    if source_response is not None:
+        # Only possible now that story.id exists (post-flush).
+        source_response.converted_story_id = story.id
 
     # Create StoryLegacy associations
     for leg_assoc in data.legacies:
@@ -336,6 +430,19 @@ async def create_story(
             "title_derived": title_derived,
         },
     )
+
+    if source_response is not None:
+        primary_legacy_id = next(
+            (leg.legacy_id for leg in data.legacies if leg.role == "primary"),
+            data.legacies[0].legacy_id,
+        )
+        story_response_service.record_conversion(
+            new_story_id=story.id,
+            source_response_id=source_response.id,
+            source_story_id=source_response.story_id,
+            legacy_id=primary_legacy_id,
+            user_id=user_id,
+        )
 
     return StoryResponse(
         id=story.id,
@@ -1026,6 +1133,12 @@ async def get_story_detail(
     legacy_ids = [assoc.legacy_id for assoc in story.legacy_associations]
     legacy_names = await _get_legacy_names(db, legacy_ids)
 
+    # Story-to-story backlinks (response-to-story conversion): this story's
+    # link back to the story it grew out of, and the reciprocal set of
+    # stories that grew out of responses left here.
+    source_story_summary = await _load_backlink_summary(db, story.source_story_id)
+    grown_from_responses = await _load_grown_from_responses(db, story.id, user_id)
+
     # Reaction types the requesting user has already made on this story, so
     # the frontend can render toggled-on state on load rather than only
     # after an in-session toggle response.
@@ -1093,6 +1206,8 @@ async def get_story_detail(
         version_count=version_count,
         has_draft=has_draft,
         source_conversation_id=story.source_conversation_id,
+        source_story=source_story_summary,
+        grown_from_responses=grown_from_responses,
         created_at=story.created_at,
         updated_at=story.updated_at,
     )

--- a/services/core-api/app/services/story.py
+++ b/services/core-api/app/services/story.py
@@ -355,6 +355,22 @@ async def create_story(
             response_id=data.source_response_id,
             user_id=user_id,
         )
+        # A converted story must stay associated with (at least one of) the
+        # source response's story's legacies — the offer's contract is "same
+        # legacy," and an arbitrary `data.legacies` here would produce a
+        # confusing cross-legacy backlink.
+        source_legacy_ids_result = await db.execute(
+            select(StoryLegacy.legacy_id).where(
+                StoryLegacy.story_id == source_response.story_id
+            )
+        )
+        source_legacy_ids = {row[0] for row in source_legacy_ids_result.all()}
+        if source_legacy_ids.isdisjoint(legacy_ids):
+            raise HTTPException(
+                status_code=400,
+                detail="A story converted from a response must be associated "
+                "with the same legacy as the response's story",
+            )
 
     provided_title = (data.title or "").strip()
     if provided_title:

--- a/services/core-api/app/services/story_response.py
+++ b/services/core-api/app/services/story_response.py
@@ -504,9 +504,12 @@ async def load_response_for_conversion(
 
     Only the response's own author may turn their writing into a standalone
     story. Raises 404 if the response does not exist or is soft-deleted, 403
-    if the actor is not its author. Intended to be called from
-    `story_service.create_story` before the story is created, within the
-    same transaction/commit as the rest of story creation.
+    if the actor is not its author, 409 if it was already converted (the
+    response only tracks a single `converted_story_id`; converting it again
+    would silently relink the note and orphan its previous converted story).
+    Intended to be called from `story_service.create_story` before the story
+    is created, within the same transaction/commit as the rest of story
+    creation.
     """
     result = await db.execute(
         select(StoryResponseModel).where(
@@ -521,6 +524,11 @@ async def load_response_for_conversion(
         raise HTTPException(
             status_code=403,
             detail="Only the response's author can convert it into a story",
+        )
+    if response.converted_story_id is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="This response has already been converted into a story",
         )
     return response
 

--- a/services/core-api/app/services/story_response.py
+++ b/services/core-api/app/services/story_response.py
@@ -20,7 +20,7 @@ from uuid import UUID
 from fastapi import HTTPException
 from opentelemetry import trace
 from prometheus_client import Counter
-from sqlalchemy import case, select, update
+from sqlalchemy import case, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -29,6 +29,7 @@ from ..models.story import Story
 from ..models.story_response import StoryResponse as StoryResponseModel
 from ..models.user import User
 from ..schemas.story_response import (
+    ConvertedStorySummary,
     StoryResponseCreate,
     StoryResponseItem,
     StoryResponseUpdate,
@@ -42,6 +43,12 @@ tracer = trace.get_tracer("core-api.story_response")
 RESPONSES_CREATED = Counter(
     "story_responses_created_total",
     "Story responses created",
+    ["service", "component"],
+)
+
+RESPONSES_CONVERTED = Counter(
+    "story_responses_converted_total",
+    "Story responses converted into standalone stories",
     ["service", "component"],
 )
 
@@ -117,7 +124,9 @@ def _primary_legacy_id(story: Story) -> UUID | None:
 
 
 def _serialize_response(
-    response: StoryResponseModel, user: User | None
+    response: StoryResponseModel,
+    user: User | None,
+    converted_story: Story | None = None,
 ) -> StoryResponseItem:
     display_name = ""
     username = ""
@@ -126,6 +135,15 @@ def _serialize_response(
         display_name = user.name or user.username
         username = user.username
         avatar_url = user.avatar_url
+
+    converted_story_summary = None
+    if converted_story is not None:
+        converted_story_summary = ConvertedStorySummary(
+            id=converted_story.id,
+            title=converted_story.title,
+            legacy_id=_primary_legacy_id(converted_story),
+        )
+
     return StoryResponseItem(
         id=response.id,
         story_id=response.story_id,
@@ -136,7 +154,30 @@ def _serialize_response(
         body=response.body,
         created_at=response.created_at,
         edited_at=response.edited_at,
+        converted_story_id=response.converted_story_id,
+        converted_story=converted_story_summary,
+        offer_dismissed_at=response.offer_dismissed_at,
+        hidden=response.hidden_at is not None,
     )
+
+
+async def _load_converted_stories(
+    db: AsyncSession, converted_story_ids: list[UUID]
+) -> dict[UUID, Story]:
+    """Batch-load converted stories (with legacy associations) by id.
+
+    A response's ``converted_story_id`` is auto-nulled by the FK when the
+    converted story is deleted, so any id passed in here is expected to
+    resolve; a miss is tolerated defensively and simply yields no summary.
+    """
+    if not converted_story_ids:
+        return {}
+    result = await db.execute(
+        select(Story)
+        .options(selectinload(Story.legacy_associations))
+        .where(Story.id.in_(converted_story_ids))
+    )
+    return {s.id: s for s in result.scalars().all()}
 
 
 async def _load_response(
@@ -291,6 +332,11 @@ async def list_responses(
     filters = [
         StoryResponseModel.story_id == story_id,
         StoryResponseModel.deleted_at.is_(None),
+        # Hidden notes are excluded from everyone but the note's own author.
+        or_(
+            StoryResponseModel.hidden_at.is_(None),
+            StoryResponseModel.user_id == user_id,
+        ),
     ]
     if cursor:
         filters.append(StoryResponseModel.created_at > cursor)
@@ -318,7 +364,21 @@ async def list_responses(
         user_rows = await db.execute(select(User).where(User.id.in_(user_ids)))
         users_by_id = {u.id: u for u in user_rows.scalars().all()}
 
-    items = [_serialize_response(r, users_by_id.get(r.user_id)) for r in responses]
+    converted_story_ids = list(
+        {r.converted_story_id for r in responses if r.converted_story_id is not None}
+    )
+    converted_stories_by_id = await _load_converted_stories(db, converted_story_ids)
+
+    items = [
+        _serialize_response(
+            r,
+            users_by_id.get(r.user_id),
+            converted_stories_by_id.get(r.converted_story_id)
+            if r.converted_story_id is not None
+            else None,
+        )
+        for r in responses
+    ]
 
     return {"items": items, "next_cursor": next_cursor, "has_more": has_more}
 
@@ -342,6 +402,12 @@ async def update_response(
         if response.user_id != user_id:
             raise HTTPException(
                 status_code=403, detail="Only the response author can edit it"
+            )
+
+        if response.converted_story_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="A converted note cannot be edited",
             )
 
         response.body = data.body
@@ -426,4 +492,176 @@ async def delete_response(
                 "response_id": str(response_id),
                 "deleted_by": "author" if is_author else "legacy_admin",
             },
+        )
+
+
+async def load_response_for_conversion(
+    db: AsyncSession,
+    response_id: UUID,
+    user_id: UUID,
+) -> StoryResponseModel:
+    """Load a response for create-from-response conversion.
+
+    Only the response's own author may turn their writing into a standalone
+    story. Raises 404 if the response does not exist or is soft-deleted, 403
+    if the actor is not its author. Intended to be called from
+    `story_service.create_story` before the story is created, within the
+    same transaction/commit as the rest of story creation.
+    """
+    result = await db.execute(
+        select(StoryResponseModel).where(
+            StoryResponseModel.id == response_id,
+            StoryResponseModel.deleted_at.is_(None),
+        )
+    )
+    response = result.scalar_one_or_none()
+    if response is None:
+        raise HTTPException(status_code=404, detail="Response not found")
+    if response.user_id != user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the response's author can convert it into a story",
+        )
+    return response
+
+
+def record_conversion(
+    *,
+    new_story_id: UUID,
+    source_response_id: UUID,
+    source_story_id: UUID,
+    legacy_id: UUID | None,
+    user_id: UUID,
+) -> None:
+    """Emit span/log/metric telemetry for a completed response-to-story conversion.
+
+    Called by `story_service.create_story` after the create-from-response
+    transaction (story creation + response linking) has committed
+    successfully.
+    """
+    with tracer.start_as_current_span("story_response.convert") as span:
+        span.set_attribute("component", "story-responses")
+        span.set_attribute("story_id", str(new_story_id))
+        span.set_attribute("source_response_id", str(source_response_id))
+        span.set_attribute("source_story_id", str(source_story_id))
+        span.set_attribute("user_id", str(user_id))
+
+    RESPONSES_CONVERTED.labels(service="core-api", component="story-responses").inc()
+    logger.info(
+        "story_response.converted",
+        extra={
+            "story_id": str(new_story_id),
+            "source_response_id": str(source_response_id),
+            "source_story_id": str(source_story_id),
+            "legacy_id": str(legacy_id) if legacy_id else None,
+            "user_id": str(user_id),
+        },
+    )
+
+
+async def dismiss_offer(
+    db: AsyncSession,
+    story_id: UUID,
+    response_id: UUID,
+    user_id: UUID,
+) -> StoryResponseItem:
+    """Dismiss the "make this a story" offer for a response. Author-only.
+
+    Persisted server-side (`offer_dismissed_at`) so dismissal is cross-device
+    and does not reappear on a later visit.
+    """
+    with tracer.start_as_current_span("story_response.dismiss_offer") as span:
+        span.set_attribute("component", "story-responses")
+        span.set_attribute("story_id", str(story_id))
+        span.set_attribute("response_id", str(response_id))
+        span.set_attribute("user_id", str(user_id))
+
+        response = await _load_response(db, story_id, response_id)
+
+        if response.user_id != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Only the response author can dismiss this offer",
+            )
+
+        response.offer_dismissed_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(response)
+
+        logger.info(
+            "story_response.offer_dismissed",
+            extra={
+                "response_id": str(response_id),
+                "user_id": str(user_id),
+            },
+        )
+
+        actor = await db.get(User, user_id)
+        converted_stories = await _load_converted_stories(
+            db,
+            [response.converted_story_id] if response.converted_story_id else [],
+        )
+        return _serialize_response(
+            response,
+            actor,
+            converted_stories.get(response.converted_story_id)
+            if response.converted_story_id
+            else None,
+        )
+
+
+async def hide_response(
+    db: AsyncSession,
+    story_id: UUID,
+    response_id: UUID,
+    user_id: UUID,
+) -> StoryResponseItem:
+    """Hide a converted note from everyone but its own author.
+
+    Authorized to the *story* author only (not legacy admin), and rejected
+    unless the target response is a converted note
+    (`converted_story_id is not None`) — this moderation power is scoped to
+    notes only in this change (see spec R2).
+    """
+    with tracer.start_as_current_span("story_response.hide") as span:
+        span.set_attribute("component", "story-responses")
+        span.set_attribute("story_id", str(story_id))
+        span.set_attribute("response_id", str(response_id))
+        span.set_attribute("user_id", str(user_id))
+
+        response = await _load_response(db, story_id, response_id)
+
+        story = await _load_story_with_legacies(db, story_id)
+        if story.author_id != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Only the story author can hide a response",
+            )
+
+        if response.converted_story_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Only a converted note can be hidden",
+            )
+
+        response.hidden_at = datetime.now(timezone.utc)
+        response.hidden_by_id = user_id
+        await db.commit()
+        await db.refresh(response)
+
+        logger.info(
+            "story_response.hidden",
+            extra={
+                "response_id": str(response_id),
+                "story_id": str(story_id),
+                "hidden_by_id": str(user_id),
+            },
+        )
+
+        note_author = await db.get(User, response.user_id)
+        converted_stories = await _load_converted_stories(
+            db, [response.converted_story_id]
+        )
+        return _serialize_response(
+            response, note_author, converted_stories.get(response.converted_story_id)
         )

--- a/services/core-api/tests/integration/test_response_to_story_flow.py
+++ b/services/core-api/tests/integration/test_response_to_story_flow.py
@@ -1,0 +1,489 @@
+"""Integration tests for the response-to-story conversion feature.
+
+Covers: create-from-response wiring (both FKs, note fields, backlinks),
+author-only conversion, author-only dismissal, story-author-only + note-only
+hiding, hidden-note list filtering, and FK-driven restore/backlink-drop on
+delete (`ondelete="SET NULL"`).
+"""
+
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.legacy import Legacy, LegacyMember
+from app.models.story import Story
+from app.models.story_response import StoryResponse as StoryResponseModel
+from app.models.user import User
+from tests.conftest import create_auth_headers_for_user
+
+
+@pytest_asyncio.fixture
+async def fk_enforced_db_session(
+    db_session: AsyncSession,
+) -> AsyncGenerator[AsyncSession, None]:
+    """`db_session`, but with SQLite FK enforcement turned on for the test.
+
+    SQLite ignores foreign keys (including ``ON DELETE SET NULL``) unless
+    ``PRAGMA foreign_keys=ON`` is issued per-connection; the shared test
+    engine does not enable it (unlike Postgres, which always enforces FKs).
+    Enforcement is turned back off in a `finally` so teardown
+    (`Base.metadata.drop_all`) isn't tripped up by the pre-existing
+    `ai_conversations`/`stories` circular FK (see the SAWarning emitted at
+    teardown across the whole suite) — this is scoped to just the two tests
+    that need to observe real `ON DELETE SET NULL` behavior, not flipped
+    globally in conftest.py where it could affect unrelated tests.
+    """
+    await db_session.execute(text("PRAGMA foreign_keys=ON"))
+    try:
+        yield db_session
+    finally:
+        await db_session.execute(text("PRAGMA foreign_keys=OFF"))
+
+
+async def _add_member(db: AsyncSession, legacy_id, user_id, role: str) -> None:
+    db.add(LegacyMember(legacy_id=legacy_id, user_id=user_id, role=role))
+    await db.commit()
+
+
+async def _make_user(db: AsyncSession, email: str, username: str) -> User:
+    user = User(
+        email=email,
+        google_id=f"google_{username}",
+        provider="google",
+        provider_id=f"google_{username}",
+        name=username.replace("-", " ").title(),
+        username=username,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _create_response(
+    client: AsyncClient, story_id, headers: dict[str, str], body: str
+) -> str:
+    resp = await client.post(
+        f"/api/stories/{story_id}/responses",
+        json={"body": body},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return str(resp.json()["id"])
+
+
+async def _convert_response(
+    client: AsyncClient,
+    response_id: str,
+    legacy_id,
+    headers: dict[str, str],
+    content: str = "A memory worth its own page, seeded verbatim.",
+) -> str:
+    resp = await client.post(
+        "/api/stories/",
+        json={
+            "content": content,
+            "legacies": [{"legacy_id": str(legacy_id)}],
+            "source_response_id": response_id,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return str(resp.json()["id"])
+
+
+class TestCreateFromResponse:
+    @pytest.mark.asyncio
+    async def test_convert_sets_both_fks(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory too big for a comment."
+        )
+        new_story_id = await _convert_response(
+            client, response_id, test_legacy.id, auth_headers
+        )
+
+        new_story = await db_session.get(Story, UUID(new_story_id))
+        assert new_story is not None
+        assert new_story.source_story_id == test_story.id
+
+        response_row = await db_session.get(StoryResponseModel, UUID(response_id))
+        assert response_row is not None
+        assert response_row.converted_story_id == UUID(new_story_id)
+
+    @pytest.mark.asyncio
+    async def test_note_fields_present_after_conversion(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory too big for a comment."
+        )
+        new_story_id = await _convert_response(
+            client, response_id, test_legacy.id, auth_headers
+        )
+
+        list_resp = await client.get(
+            f"/api/stories/{test_story.id}/responses", headers=auth_headers
+        )
+        items = list_resp.json()["items"]
+        assert len(items) == 1
+        item = items[0]
+        assert item["converted_story_id"] == new_story_id
+        assert item["converted_story"]["id"] == new_story_id
+        assert item["converted_story"]["legacy_id"] == str(test_legacy.id)
+        assert item["hidden"] is False
+        assert item["offer_dismissed_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_backlink_fields_on_new_story_and_source_story(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory too big for a comment."
+        )
+        new_story_id = await _convert_response(
+            client, response_id, test_legacy.id, auth_headers
+        )
+
+        new_story_detail = await client.get(
+            f"/api/stories/{new_story_id}", headers=auth_headers
+        )
+        assert new_story_detail.status_code == 200
+        source_story = new_story_detail.json()["source_story"]
+        assert source_story is not None
+        assert source_story["id"] == str(test_story.id)
+        assert source_story["title"] == test_story.title
+
+        source_story_detail = await client.get(
+            f"/api/stories/{test_story.id}", headers=auth_headers
+        )
+        assert source_story_detail.status_code == 200
+        grown = source_story_detail.json()["grown_from_responses"]
+        assert len(grown) == 1
+        assert grown[0]["id"] == new_story_id
+
+    @pytest.mark.asyncio
+    async def test_convert_denied_for_non_author(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_user_2: User,
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "My own long memory, not yours."
+        )
+
+        await _add_member(db_session, test_legacy.id, test_user_2.id, "advocate")
+        other_headers = create_auth_headers_for_user(test_user_2)
+
+        resp = await client.post(
+            "/api/stories/",
+            json={
+                "content": "Stolen memory",
+                "legacies": [{"legacy_id": str(test_legacy.id)}],
+                "source_response_id": response_id,
+            },
+            headers=other_headers,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_convert_denied_for_nonexistent_response(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+    ):
+        fake_id = "00000000-0000-0000-0000-000000000000"
+        resp = await client.post(
+            "/api/stories/",
+            json={
+                "content": "No such response",
+                "legacies": [{"legacy_id": str(test_legacy.id)}],
+                "source_response_id": fake_id,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_converted_note_cannot_be_edited(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory too big for a comment."
+        )
+        await _convert_response(client, response_id, test_legacy.id, auth_headers)
+
+        resp = await client.patch(
+            f"/api/stories/{test_story.id}/responses/{response_id}",
+            json={"body": "Trying to edit the note anyway."},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+class TestDismissOffer:
+    @pytest.mark.asyncio
+    async def test_author_can_dismiss(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A response."
+        )
+
+        resp = await client.post(
+            f"/api/stories/{test_story.id}/responses/{response_id}/dismiss-offer",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["offer_dismissed_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_non_author_cannot_dismiss(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_user_2: User,
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A response."
+        )
+
+        await _add_member(db_session, test_legacy.id, test_user_2.id, "advocate")
+        other_headers = create_auth_headers_for_user(test_user_2)
+
+        resp = await client.post(
+            f"/api/stories/{test_story.id}/responses/{response_id}/dismiss-offer",
+            headers=other_headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestHideNote:
+    @pytest.mark.asyncio
+    async def test_story_author_can_hide_note(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_user_2: User,
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        await _add_member(db_session, test_legacy.id, test_user_2.id, "advocate")
+        note_author_headers = create_auth_headers_for_user(test_user_2)
+
+        response_id = await _create_response(
+            client, test_story.id, note_author_headers, "A memory of my own."
+        )
+        await _convert_response(
+            client, response_id, test_legacy.id, note_author_headers
+        )
+
+        resp = await client.post(
+            f"/api/stories/{test_story.id}/responses/{response_id}/hide",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["hidden"] is True
+
+    @pytest.mark.asyncio
+    async def test_hide_rejected_for_non_note(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_story: Story,
+    ):
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A normal, unconverted response."
+        )
+
+        resp = await client.post(
+            f"/api/stories/{test_story.id}/responses/{response_id}/hide",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_hide_rejected_for_non_story_author(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_user_2: User,
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        # test_user (auth_headers) is both the story author and the note's
+        # own author here; test_user_2 is a legacy *admin* (not the story
+        # author) and must still be denied — hide is story-author-only, not
+        # a general legacy-admin power.
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory of my own story."
+        )
+        await _convert_response(client, response_id, test_legacy.id, auth_headers)
+
+        await _add_member(db_session, test_legacy.id, test_user_2.id, "admin")
+        admin_headers = create_auth_headers_for_user(test_user_2)
+
+        resp = await client.post(
+            f"/api/stories/{test_story.id}/responses/{response_id}/hide",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_hidden_note_filtered_for_others_but_visible_to_author(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_user_2: User,
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        await _add_member(db_session, test_legacy.id, test_user_2.id, "advocate")
+        note_author_headers = create_auth_headers_for_user(test_user_2)
+
+        response_id = await _create_response(
+            client, test_story.id, note_author_headers, "A memory of my own."
+        )
+        await _convert_response(
+            client, response_id, test_legacy.id, note_author_headers
+        )
+
+        hide_resp = await client.post(
+            f"/api/stories/{test_story.id}/responses/{response_id}/hide",
+            headers=auth_headers,
+        )
+        assert hide_resp.status_code == 200
+
+        # The note's own author still sees it.
+        list_as_author = await client.get(
+            f"/api/stories/{test_story.id}/responses", headers=note_author_headers
+        )
+        ids = [item["id"] for item in list_as_author.json()["items"]]
+        assert response_id in ids
+
+        # A third, unrelated member does not see it.
+        third_user = await _make_user(db_session, "third@example.com", "third-member")
+        await _add_member(db_session, test_legacy.id, third_user.id, "advocate")
+        third_headers = create_auth_headers_for_user(third_user)
+        list_as_third = await client.get(
+            f"/api/stories/{test_story.id}/responses", headers=third_headers
+        )
+        ids_third = [item["id"] for item in list_as_third.json()["items"]]
+        assert response_id not in ids_third
+
+        # The story author (who hid it) does not see it either, since they
+        # are not the note's own author.
+        list_as_story_author = await client.get(
+            f"/api/stories/{test_story.id}/responses", headers=auth_headers
+        )
+        ids_story_author = [item["id"] for item in list_as_story_author.json()["items"]]
+        assert response_id not in ids_story_author
+
+
+class TestRestoreAndBacklinkDrop:
+    @pytest.mark.asyncio
+    async def test_deleting_converted_story_restores_response(
+        self,
+        client: AsyncClient,
+        fk_enforced_db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        db_session = fk_enforced_db_session
+
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory worth its own page."
+        )
+        new_story_id = await _convert_response(
+            client, response_id, test_legacy.id, auth_headers
+        )
+
+        response_row = await db_session.get(StoryResponseModel, UUID(response_id))
+        assert response_row is not None
+        assert response_row.converted_story_id == UUID(new_story_id)
+
+        delete_resp = await client.delete(
+            f"/api/stories/{new_story_id}", headers=auth_headers
+        )
+        assert delete_resp.status_code == 204
+
+        # The Postgres ON DELETE SET NULL fires at the DB layer, invisible
+        # to the ORM's unit-of-work — re-fetch rather than trust the
+        # (possibly stale, expire_on_commit=False) identity-map object.
+        await db_session.refresh(response_row)
+        assert response_row.converted_story_id is None
+
+        list_resp = await client.get(
+            f"/api/stories/{test_story.id}/responses", headers=auth_headers
+        )
+        item = next(i for i in list_resp.json()["items"] if i["id"] == response_id)
+        assert item["converted_story_id"] is None
+        assert item["converted_story"] is None
+
+    @pytest.mark.asyncio
+    async def test_deleting_source_story_drops_backlink(
+        self,
+        client: AsyncClient,
+        fk_enforced_db_session: AsyncSession,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        db_session = fk_enforced_db_session
+
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "Another memory worth its own page."
+        )
+        new_story_id = await _convert_response(
+            client, response_id, test_legacy.id, auth_headers
+        )
+
+        new_story_row = await db_session.get(Story, UUID(new_story_id))
+        assert new_story_row is not None
+        assert new_story_row.source_story_id == test_story.id
+
+        delete_resp = await client.delete(
+            f"/api/stories/{test_story.id}", headers=auth_headers
+        )
+        assert delete_resp.status_code == 204
+
+        await db_session.refresh(new_story_row)
+        assert new_story_row.source_story_id is None

--- a/services/core-api/tests/integration/test_response_to_story_flow.py
+++ b/services/core-api/tests/integration/test_response_to_story_flow.py
@@ -229,6 +229,60 @@ class TestCreateFromResponse:
         assert resp.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_convert_denied_for_mismatched_legacy(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_legacy_2: Legacy,
+        test_story: Story,
+    ):
+        """The converted story must share a legacy with the source response's
+        story — an arbitrary `legacies` list would produce a confusing
+        cross-legacy backlink and violate the offer's "same legacy" contract.
+        """
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory that belongs here."
+        )
+
+        resp = await client.post(
+            "/api/stories/",
+            json={
+                "content": "Wrong legacy entirely",
+                "legacies": [{"legacy_id": str(test_legacy_2.id)}],
+                "source_response_id": response_id,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_convert_denied_for_already_converted_response(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        test_legacy: Legacy,
+        test_story: Story,
+    ):
+        """Converting the same response twice would silently relink the note
+        and orphan its first converted story — must be rejected.
+        """
+        response_id = await _create_response(
+            client, test_story.id, auth_headers, "A memory worth its own page."
+        )
+        await _convert_response(client, response_id, test_legacy.id, auth_headers)
+
+        resp = await client.post(
+            "/api/stories/",
+            json={
+                "content": "Trying to convert it again",
+                "legacies": [{"legacy_id": str(test_legacy.id)}],
+                "source_response_id": response_id,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
     async def test_converted_note_cannot_be_edited(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## Summary

Closes the story-responses stretch tasks (3.7 / 7.1–7.3) deferred by the archived `story-responses` change. Lets a member turn their own long response into a standalone story:

- On a member's **own** response of **more than four sentences**, a gentle, dismissible inline offer appears ("This sounds like its own story"). Never shown on other members' responses or short responses; dismissal is persisted server-side per response.
- Taking the offer opens the story Edit page pre-seeded with the response's **raw text verbatim**, in the **same legacy**, defaulting to **private**. A "not saved yet" indicator explains that an edit is needed to persist the draft (create is lazy, matching existing Edit-page behavior).
- Once the story is actually created, the original response becomes a **non-editable note** ("Turned this into a story →") linking to the new story; its author can still delete it. If the new story is later deleted, the response is **automatically restored** (via `ON DELETE SET NULL` FKs — no app code needed).
- The new story records a **backlink** to the source story, rendered on both sides ("grew out of a memory on …" / "stories grown from responses").
- The **story author** can **hide a converted note** so it stays visible to its own author but disappears for everyone else — scoped to converted notes only; existing response removal rights are unchanged.

## Changes

- **Backend** (`services/core-api`): two additive Alembic migrations (`story_responses.converted_story_id/hidden_at/hidden_by_id/offer_dismissed_at`, `stories.source_story_id`), create-from-response wiring in one transaction, `dismiss-offer`/`hide` endpoints, list filtering for hidden notes, and a guard rejecting edits to converted notes. 14 new integration tests; full suite green (1383 passed, 2 pre-existing skips); `just validate-backend` clean.
- **Frontend** (`apps/web`): `isLongResponse` util, offer UI with dismiss, seed-and-navigate into the Edit page, converted-note rendering, story-to-story backlinks, story-author hide affordance. Full test suite green (469 tests); lint and `tsc --noEmit` clean.
- **OpenSpec**: `openspec/changes/response-to-story/` (proposal, design, spec deltas, tasks — all 29 tasks complete).

## Test plan

- [x] `just validate-backend` (ruff + mypy) — clean
- [x] `uv run pytest` (services/core-api) — 1383 passed, 2 pre-existing skips
- [x] `npm run lint` / `npm run test` (apps/web) — clean, 469 passed
- [x] `npx tsc --noEmit` — clean
- [x] Manually drove the full flow end-to-end against the live docker-compose stack (two real authenticated users): offer visibility (author-only), verbatim seeding with no blockquote, private default, "not saved yet" indicator, lazy-create, note rendering, bidirectional backlinks, restore-on-delete, hide (disappears for others, stays for the note's own author), dismissal persistence across reload. No unexpected backend errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)